### PR TITLE
[FIX/#39] 최근 길 안내 장소 조회 오류 해결 

### DIFF
--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -133,8 +133,8 @@ public class MemberService {
             GuidedSpotEntity guidedSpotEntity = optionalGuidedSpotEntity.get();
             GuidedSpot guidedSpot = guidedSpotMapper.toDomain(guidedSpotEntity);
             guidedSpot.setUpdatedAt(LocalDateTime.now());
-            GuidedSpotEntity updatedRecentGuidedSpotEntity = guidedSpotMapper.toEntity(guidedSpot);
-            guidedSpotRepository.save(updatedRecentGuidedSpotEntity);
+            GuidedSpotEntity updateGuidedSpotEntity = guidedSpotMapper.toEntity(guidedSpot);
+            guidedSpotRepository.save(updateGuidedSpotEntity);
         } else {
             GuidedSpotEntity newGuidedSpotEntity = GuidedSpotEntity.builder()
                     .memberId(memberId)

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -7,8 +7,10 @@ import com.acon.server.global.external.NaverMapsClient;
 import com.acon.server.member.api.request.LoginRequest;
 import com.acon.server.member.api.response.AcornCountResponse;
 import com.acon.server.member.api.response.LoginResponse;
+import com.acon.server.member.application.mapper.GuidedSpotMapper;
 import com.acon.server.member.application.mapper.MemberMapper;
 import com.acon.server.member.application.mapper.PreferenceMapper;
+import com.acon.server.member.domain.entity.GuidedSpot;
 import com.acon.server.member.domain.entity.Member;
 import com.acon.server.member.domain.entity.Preference;
 import com.acon.server.member.domain.enums.Cuisine;
@@ -27,9 +29,11 @@ import com.acon.server.member.infra.repository.VerifiedAreaRepository;
 import com.acon.server.spot.domain.enums.SpotType;
 import com.acon.server.spot.infra.repository.SpotRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +53,7 @@ public class MemberService {
 
     private final MemberMapper memberMapper;
     private final PreferenceMapper preferenceMapper;
+    private final GuidedSpotMapper guidedSpotMapper;
 
     private final JwtUtils jwtUtils;
     private final GoogleSocialService googleSocialService;
@@ -121,11 +126,22 @@ public class MemberService {
             throw new BusinessException(ErrorType.NOT_FOUND_SPOT_ERROR);
         }
 
-        GuidedSpotEntity guidedSpotEntity = GuidedSpotEntity.builder()
-                .memberId(memberId)
-                .spotId(spotId)
-                .build();
-        guidedSpotRepository.save(guidedSpotEntity);
+        Optional<GuidedSpotEntity> optionalGuidedSpotEntity = guidedSpotRepository.findByMemberIdAndSpotId(
+                memberId, spotId);
+
+        if (optionalGuidedSpotEntity.isPresent()) {
+            GuidedSpotEntity guidedSpotEntity = optionalGuidedSpotEntity.get();
+            GuidedSpot guidedSpot = guidedSpotMapper.toDomain(guidedSpotEntity);
+            guidedSpot.setUpdatedAt(LocalDateTime.now());
+            GuidedSpotEntity updatedRecentGuidedSpotEntity = guidedSpotMapper.toEntity(guidedSpot);
+            guidedSpotRepository.save(updatedRecentGuidedSpotEntity);
+        } else {
+            GuidedSpotEntity newGuidedSpotEntity = GuidedSpotEntity.builder()
+                    .memberId(memberId)
+                    .spotId(spotId)
+                    .build();
+            guidedSpotRepository.save(newGuidedSpotEntity);
+        }
     }
 
     public String createMemberArea(final Double latitude, final Double longitude, final Long memberId) {

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -126,22 +126,23 @@ public class MemberService {
             throw new BusinessException(ErrorType.NOT_FOUND_SPOT_ERROR);
         }
 
-        Optional<GuidedSpotEntity> optionalGuidedSpotEntity = guidedSpotRepository.findByMemberIdAndSpotId(
-                memberId, spotId);
+        Optional<GuidedSpotEntity> optionalGuidedSpotEntity = guidedSpotRepository.findByMemberIdAndSpotId(memberId,
+                spotId);
 
-        if (optionalGuidedSpotEntity.isPresent()) {
-            GuidedSpotEntity guidedSpotEntity = optionalGuidedSpotEntity.get();
-            GuidedSpot guidedSpot = guidedSpotMapper.toDomain(guidedSpotEntity);
-            guidedSpot.setUpdatedAt(LocalDateTime.now());
-            GuidedSpotEntity updateGuidedSpotEntity = guidedSpotMapper.toEntity(guidedSpot);
-            guidedSpotRepository.save(updateGuidedSpotEntity);
-        } else {
-            GuidedSpotEntity newGuidedSpotEntity = GuidedSpotEntity.builder()
-                    .memberId(memberId)
-                    .spotId(spotId)
-                    .build();
-            guidedSpotRepository.save(newGuidedSpotEntity);
-        }
+        optionalGuidedSpotEntity.ifPresentOrElse(
+                guidedSpotEntity -> {
+                    GuidedSpot guidedSpot = guidedSpotMapper.toDomain(guidedSpotEntity);
+                    guidedSpot.setUpdatedAt(LocalDateTime.now());
+                    guidedSpotRepository.save(guidedSpotMapper.toEntity(guidedSpot));
+                },
+                () -> guidedSpotRepository.save(
+                        GuidedSpotEntity.builder()
+                                .memberId(memberId)
+                                .spotId(spotId)
+                                .build()
+                )
+        );
+
     }
 
     public String createMemberArea(final Double latitude, final Double longitude, final Long memberId) {

--- a/src/main/java/com/acon/server/member/domain/entity/GuidedSpot.java
+++ b/src/main/java/com/acon/server/member/domain/entity/GuidedSpot.java
@@ -3,9 +3,11 @@ package com.acon.server.member.domain.entity;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
+@Setter
 @ToString
 public class GuidedSpot {
 

--- a/src/main/java/com/acon/server/member/infra/repository/GuidedSpotRepository.java
+++ b/src/main/java/com/acon/server/member/infra/repository/GuidedSpotRepository.java
@@ -1,8 +1,10 @@
 package com.acon.server.member.infra.repository;
 
 import com.acon.server.member.infra.entity.GuidedSpotEntity;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GuidedSpotRepository extends JpaRepository<GuidedSpotEntity, Long> {
 
+    Optional<GuidedSpotEntity> findByMemberIdAndSpotId(Long memberId, Long spotId);
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #39 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
<img width="779" alt="image" src="https://github.com/user-attachments/assets/4cabf1de-5243-4cb3-bd16-f0fbdf7dc4af" />


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 길 안내 장소의 현재 로직은 동일한 장소아이디, 멤버 아이디를 가진 행이 있으면 에러를 반환
- 하지만 동일한 장소 아이디, 멤버 아이디를 가진 행이 있으면 업데이트를 해줘야합니다 ( 검색 기록과 로직이 동일하게 !)
- 그래서 RecentGuidedSpotEntity가 존재하면 updatedAt을 수정하구 존재하지 않으면 새로 생성해서 save하도록 구현했습니다

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->


# 🔗 Reference
<!-- 이슈를 해결하며 도움이 되었거나, 참고했던 아티클들의 링크를 첨부해 주세요 -->
- 
