### PR TITLE
[FEAT/#52] 메인 페이지 상세 조건 필터링 구현 

### DIFF
--- a/src/main/java/com/acon/server/spot/api/request/SpotListRequest.java
+++ b/src/main/java/com/acon/server/spot/api/request/SpotListRequest.java
@@ -18,17 +18,17 @@ public record SpotListRequest(
         Double longitude,
 
         @NotNull(message = "상세 조건은 필수 입력값입니다.")
-        Condition condition,
-
-        @Positive(message = "도보 가능 거리는 양수여야 합니다.")
-        Integer walkingTime
+        Condition condition
 ) {
 
     public static record Condition(
             String spotType,
             List<Filter> filterList,
             @Positive(message = "가격대는 양수여야 합니다.")
-            Integer priceRange
+            Integer priceRange,
+
+            @Positive(message = "도보 가능 거리는 양수여야 합니다.")
+            Integer walkingTime
     ) {
 
         public static record Filter(

--- a/src/main/java/com/acon/server/spot/api/request/SpotListRequest.java
+++ b/src/main/java/com/acon/server/spot/api/request/SpotListRequest.java
@@ -21,15 +21,14 @@ public record SpotListRequest(
         Condition condition,
 
         @Positive(message = "도보 가능 거리는 양수여야 합니다.")
-        Integer walkingTime,
-
-        @Positive(message = "가격대는 양수여야 합니다.")
-        Integer priceRange
+        Integer walkingTime
 ) {
 
     public static record Condition(
             String spotType,
-            List<Filter> filterList
+            List<Filter> filterList,
+            @Positive(message = "가격대는 양수여야 합니다.")
+            Integer priceRange
     ) {
 
         public static record Filter(

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -284,6 +284,7 @@ public class SpotService {
                 .toList();
     }
 
+    // TODO: 검색어 문자가 첫 문자인 가게로 정렬
     public SearchSpotListResponse searchSpot(final String keyword) {
         List<SpotEntity> spotEntityList = spotRepository.findTop10ByNameContainsIgnoreCase(keyword);
 

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -122,6 +122,16 @@ public class SpotService {
         return new SpotListResponse(spotList);
     }
 
+    public List<Spot> filterSpotList(SpotListRequest request) {
+        // 1. SpotType ( 음식점, 카페 ) 로 필터링
+
+        // 2. filterList를 기반으로 수정 ( 음식 특성 or 카페 특성, 함께 하는 사람 or 방문 목적 )
+
+        // 3. 가격 범위
+
+        // 4. 도보 가능 거리 15분 ( 1km )
+    }
+
     // Spot -> RecommendedSpot 변환 메서드
     private RecommendedSpot toRecommendedSpot(SpotEntity spotEntity) {
         return new RecommendedSpot(

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -131,6 +131,7 @@ public class SpotService {
         return new SpotListResponse(spotList);
     }
 
+    // TODO enum 처리 급해요 
     public List<SpotEntity> filterSpotList(SpotListRequest request) {
         return spotNativeQueryRepository.findSpotsWithinDistance(
                 request.latitude(), request.longitude(),
@@ -138,7 +139,7 @@ public class SpotService {
                 request.condition().spotType(),
                 request.condition().priceRange(),
                 request.condition()
-                        .filterList()
+                        .filterList(), 6
         );
     }
 

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -131,6 +131,7 @@ public class SpotService {
         return new SpotListResponse(spotList);
     }
 
+    @Transactional(readOnly = true)
     public List<SpotEntity> filterSpotList(SpotListRequest request) {
         return spotNativeQueryRepository.findSpotsWithinDistance(
                 request.latitude(), request.longitude(),

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -131,7 +131,6 @@ public class SpotService {
         return new SpotListResponse(spotList);
     }
 
-    @Transactional(readOnly = true)
     public List<SpotEntity> filterSpotList(SpotListRequest request) {
         return spotNativeQueryRepository.findSpotsWithinDistance(
                 request.latitude(), request.longitude(),

--- a/src/main/java/com/acon/server/spot/domain/enums/CafeFeature.java
+++ b/src/main/java/com/acon/server/spot/domain/enums/CafeFeature.java
@@ -1,0 +1,37 @@
+package com.acon.server.spot.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CafeFeature {
+    LARGE,
+    GOOD_VIEW,
+    DESSERT,
+    TERRACE,
+    EXCLUDE_FRANCHISE;
+
+    private static final Map<String, CafeFeature> CAFE_FEATURE_MAP = new HashMap<>();
+
+    static {
+        for (CafeFeature cafeFeature : CafeFeature.values()) {
+            CAFE_FEATURE_MAP.put(cafeFeature.name(), cafeFeature);
+        }
+    }
+
+    public static CafeFeature fromValue(String value) {
+        CafeFeature spotType = CAFE_FEATURE_MAP.get(value);
+
+        if (spotType == null) {
+            throw new BusinessException(ErrorType.INVALID_SPOT_TYPE_ERROR);
+        }
+
+        return spotType;
+    }
+}

--- a/src/main/java/com/acon/server/spot/domain/enums/CompanionType.java
+++ b/src/main/java/com/acon/server/spot/domain/enums/CompanionType.java
@@ -1,0 +1,37 @@
+package com.acon.server.spot.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CompanionType {
+    FAMILY,
+    DATE,
+    FRIEND,
+    ALONE,
+    GROUP;
+
+    private static final Map<String, CompanionType> COMPANION_TYPE_MAP = new HashMap<>();
+
+    static {
+        for (CompanionType companionType : CompanionType.values()) {
+            COMPANION_TYPE_MAP.put(companionType.name(), companionType);
+        }
+    }
+
+    public static CompanionType fromValue(String value) {
+        CompanionType type = COMPANION_TYPE_MAP.get(value);
+
+        if (type == null) {
+            throw new BusinessException(ErrorType.INVALID_SPOT_TYPE_ERROR);
+        }
+
+        return type;
+    }
+}

--- a/src/main/java/com/acon/server/spot/domain/enums/FilterCategory.java
+++ b/src/main/java/com/acon/server/spot/domain/enums/FilterCategory.java
@@ -1,0 +1,37 @@
+package com.acon.server.spot.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum FilterCategory {
+    RESTAURANT_FEATURE,
+    CAFE_FEATURE,
+    VISIT_PURPOSE,
+    COMPANION_TYPE;
+
+    private static final Map<String, FilterCategory> FILTER_CATEGORY_MAP = new HashMap<>();
+
+    static {
+        for (FilterCategory filterCategory : FilterCategory.values()) {
+            FILTER_CATEGORY_MAP.put(filterCategory.name(), filterCategory);
+        }
+    }
+
+    public static FilterCategory fromValue(String value) {
+        FilterCategory category = FILTER_CATEGORY_MAP.get(value);
+
+        if (category == null) {
+            throw new BusinessException(ErrorType.INVALID_SPOT_TYPE_ERROR);
+        }
+
+        return category;
+    }
+
+}

--- a/src/main/java/com/acon/server/spot/domain/enums/RestaurantFeature.java
+++ b/src/main/java/com/acon/server/spot/domain/enums/RestaurantFeature.java
@@ -1,0 +1,40 @@
+package com.acon.server.spot.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum RestaurantFeature {
+    KOREAN,
+    JAPANESE,
+    CHINESE,
+    WESTERN,
+    KOREAN_STREET,
+    ASIAN,
+    BAR,
+    EXCLUDE_FRANCHISE;
+
+    private static final Map<String, RestaurantFeature> RESTAURANT_FEATURE_MAP = new HashMap<>();
+
+    static {
+        for (RestaurantFeature restaurantFeature : RestaurantFeature.values()) {
+            RESTAURANT_FEATURE_MAP.put(restaurantFeature.name(), restaurantFeature);
+        }
+    }
+
+    public static RestaurantFeature fromValue(String value) {
+        RestaurantFeature feature = RESTAURANT_FEATURE_MAP.get(value);
+
+        if (feature == null) {
+            throw new BusinessException(ErrorType.INVALID_SPOT_TYPE_ERROR);
+        }
+
+        return feature;
+    }
+}

--- a/src/main/java/com/acon/server/spot/domain/enums/VisitPurpose.java
+++ b/src/main/java/com/acon/server/spot/domain/enums/VisitPurpose.java
@@ -1,0 +1,34 @@
+package com.acon.server.spot.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum VisitPurpose {
+    MEETING,
+    STUDY;
+
+    private static final Map<String, VisitPurpose> VISIT_PURPOSE_MAP = new HashMap<>();
+
+    static {
+        for (VisitPurpose visitPurpose : VisitPurpose.values()) {
+            VISIT_PURPOSE_MAP.put(visitPurpose.name(), visitPurpose);
+        }
+    }
+
+    public static VisitPurpose fromValue(String value) {
+        VisitPurpose purpose = VISIT_PURPOSE_MAP.get(value);
+
+        if (purpose == null) {
+            throw new BusinessException(ErrorType.INVALID_SPOT_TYPE_ERROR);
+        }
+
+        return purpose;
+    }
+}

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+// TODO: 리팩토링
 @Repository
 public class SpotNativeQueryRepository {
 
@@ -21,10 +22,10 @@ public class SpotNativeQueryRepository {
             Double lng,
             Double distanceMeter,
             String spotType,
-            List<Filter> filterList,
-            Integer priceRange
+            Integer priceRange,
+            List<Filter> filterList
     ) {
-        // 1) 기본 쿼리 골격
+        // 1) 기본 쿼리
         StringBuilder sb = new StringBuilder();
         sb.append("SELECT s.* ")
                 .append("FROM spot s ")
@@ -48,9 +49,8 @@ public class SpotNativeQueryRepository {
             }
         }
 
-        // 3) ORDER BY / LIMIT
-        sb.append("ORDER BY s.matching_rate DESC ")
-                .append("LIMIT 6 ");
+        // 3) LIMIT
+        sb.append("LIMIT 6 ");
 
         // 4) Native Query 생성
         Query query = entityManager.createNativeQuery(sb.toString(), SpotEntity.class);
@@ -66,17 +66,12 @@ public class SpotNativeQueryRepository {
         if (filterList != null && !filterList.isEmpty()) {
             for (int i = 0; i < filterList.size(); i++) {
                 Filter filter = filterList.get(i);
-
-                // category 파라미터
                 query.setParameter("categoryName_" + i, filter.category());
-
-                // optionList 파라미터 (List<String>)
                 query.setParameter("optionNames_" + i, filter.optionList());
             }
         }
 
         // 6) 쿼리 실행
-        @SuppressWarnings("unchecked")
         List<SpotEntity> result = query.getResultList();
 
         return result;

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
@@ -1,0 +1,84 @@
+package com.acon.server.spot.infra.repository;
+
+import com.acon.server.spot.api.request.SpotListRequest.Condition.Filter;
+import com.acon.server.spot.infra.entity.SpotEntity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class SpotNativeQueryRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional(readOnly = true)
+    public List<SpotEntity> findSpotsWithinDistance(
+            Double lat,
+            Double lng,
+            Double distanceMeter,
+            String spotType,
+            List<Filter> filterList,
+            Integer priceRange
+    ) {
+        // 1) 기본 쿼리 골격
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT s.* ")
+                .append("FROM spot s ")
+                .append("WHERE ")
+                .append("ST_DWithin(s.geom::geography, ST_SetSRID(ST_MakePoint(:lng, :lat), 4326)::geography, :distanceMeter) ")
+                .append("AND (:spotType IS NULL OR s.spot_type = :spotType) ")
+                .append("AND (:priceRange IS NULL OR EXISTS ( ")
+                .append("SELECT 1 FROM menu m WHERE m.spot_id = s.id AND m.main_menu = TRUE AND m.price <= :priceRange)) ");
+
+        // 2) filterList가 있는 경우, 각 항목마다 AND EXISTS 서브쿼리 추가
+        if (filterList != null && !filterList.isEmpty()) {
+            for (int i = 0; i < filterList.size(); i++) {
+                sb.append("AND EXISTS (")
+                        .append("SELECT 1 FROM spot_option so ")
+                        .append("JOIN \"option\" o ON o.id = so.option_id ")
+                        .append("JOIN category c ON c.id = o.category_id ")
+                        .append("WHERE so.spot_id = s.id ")
+                        .append("AND c.name = :categoryName_").append(i).append(" ")
+                        .append("AND o.name IN (:optionNames_").append(i).append(") ")
+                        .append(") ");
+            }
+        }
+
+        // 3) ORDER BY / LIMIT
+        sb.append("ORDER BY s.matching_rate DESC ")
+                .append("LIMIT 6 ");
+
+        // 4) Native Query 생성
+        Query query = entityManager.createNativeQuery(sb.toString(), SpotEntity.class);
+
+        // 5) 파라미터 바인딩
+        query.setParameter("lat", lat);
+        query.setParameter("lng", lng);
+        query.setParameter("distanceMeter", distanceMeter);
+        query.setParameter("spotType", spotType);
+        query.setParameter("priceRange", priceRange);
+
+        // filterList 파라미터 바인딩
+        if (filterList != null && !filterList.isEmpty()) {
+            for (int i = 0; i < filterList.size(); i++) {
+                Filter filter = filterList.get(i);
+
+                // category 파라미터
+                query.setParameter("categoryName_" + i, filter.category());
+
+                // optionList 파라미터 (List<String>)
+                query.setParameter("optionNames_" + i, filter.optionList());
+            }
+        }
+
+        // 6) 쿼리 실행
+        @SuppressWarnings("unchecked")
+        List<SpotEntity> result = query.getResultList();
+
+        return result;
+    }
+}

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
@@ -23,7 +23,8 @@ public class SpotNativeQueryRepository {
             Double distanceMeter,
             String spotType,
             Integer priceRange,
-            List<Filter> filterList
+            List<Filter> filterList,
+            int limit
     ) {
         // 1) 기본 쿼리
         StringBuilder sb = new StringBuilder();
@@ -50,7 +51,7 @@ public class SpotNativeQueryRepository {
         }
 
         // 3) LIMIT
-        sb.append("LIMIT 6 ");
+        sb.append("LIMIT ").append(limit);
 
         // 4) Native Query 생성
         Query query = entityManager.createNativeQuery(sb.toString(), SpotEntity.class);


### PR DESCRIPTION
# 💡 Issue
- resolved: #52 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
테스트를 위해서 "서교동 그 카페" 데이터 조작 
- 해당 카페의 위도 경도를 현재 위도 경도와 일치하도록 변경
- 해당 카페에 2000원 아메리카노 메뉴 추가
- GOOD_VIEW라는 카페 특징 추가 

1. 모든 조건에 일치할 때 
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/ca8d24f1-364e-4bd6-95be-e7b9bfe1c03a" />
2. 카페 특징의 하나 조건에만 해당할 때
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/007e444a-312a-4ec9-825e-a53046c92605" />
3. 가격 범위 조건에 해당하지 않을 때
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/98972f28-ccdd-4ef5-aba4-01d8d2328128" />
4. 필터 조건에 해당하지 않을 때
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/63043003-c937-4c83-924b-3f26662bd5cf" />



# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- enum 처리를 아직 안해서 null 값이 아닌 잘못된 값이 들어왔을 때 처리를 해주지 못하고 있어요 이 부분은 급하게 수정이 필요하지만, 빠르게 조금이라도 구현하는 게 중요할 것 같아서 제외했습니다. 
- 단일 쿼리를 통해 필터링을 구현했어요 가독성이 조금 안 좋은 것 같지만 네트워크 호출 횟수를 줄이고 복잡성을 줄이기 위해 단일 쿼리를 사용했어요
- 추후 리팩토링 진행할게요!
