### PR TITLE
[REFACTOR/#66] 추천 검색어 조회 API 로직 수정

### DIFF
--- a/src/main/java/com/acon/server/member/infra/repository/GuidedSpotCustomRepository.java
+++ b/src/main/java/com/acon/server/member/infra/repository/GuidedSpotCustomRepository.java
@@ -1,0 +1,50 @@
+package com.acon.server.member.infra.repository;
+
+import com.acon.server.spot.api.response.SearchSuggestionResponse;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GuidedSpotCustomRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<SearchSuggestionResponse> findRecentGuidedSpotSuggestions(
+            Long memberId,
+            double lat,
+            double lon,
+            double range,
+            int limit
+    ) {
+        String sql = """
+                    SELECT s.id AS spot_id,
+                           s.name AS spot_name
+                    FROM guided_spot gs
+                    JOIN spot s ON s.id = gs.spot_id
+                    WHERE gs.member_id = :memberId
+                      AND ST_DWithin(
+                          s.geom::geography,
+                          ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,
+                          :range
+                      )
+                    ORDER BY gs.updated_at DESC
+                    LIMIT :limit
+                """;
+
+        Query nativeQuery = em.createNativeQuery(sql, "SearchSuggestionResponseMapping");
+        nativeQuery.setParameter("memberId", memberId);
+        nativeQuery.setParameter("lat", lat);
+        nativeQuery.setParameter("lon", lon);
+        nativeQuery.setParameter("range", range);
+        nativeQuery.setParameter("limit", limit);
+
+        @SuppressWarnings("unchecked")
+        List<SearchSuggestionResponse> result = nativeQuery.getResultList();
+
+        return result;
+    }
+}

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -15,6 +15,7 @@ import com.acon.server.member.domain.enums.FavoriteSpot;
 import com.acon.server.member.domain.enums.SpotStyle;
 import com.acon.server.member.infra.entity.MemberEntity;
 import com.acon.server.member.infra.entity.PreferenceEntity;
+import com.acon.server.member.infra.repository.GuidedSpotCustomRepository;
 import com.acon.server.member.infra.repository.GuidedSpotRepository;
 import com.acon.server.member.infra.repository.MemberRepository;
 import com.acon.server.member.infra.repository.PreferenceRepository;
@@ -67,12 +68,13 @@ public class SpotService {
 
     private final PreferenceRepository preferenceRepository;
 
-    // TODO: 매직 넘버 yml로 옮기기, 250m로 바꾸고 변수명 수정
-    private static final int WALKING_RADIUS_30_MIN = 2000;
+    // TODO: 매직 넘버 yml로 옮기기
+    private static final int SUGGESTION_RADIUS = 250;
     private static final int SUGGESTION_LIMIT = 5;
     private static final int VERIFICATION_DISTANCE = 250;
     private static final int SEARCH_LIMIT = 10;
 
+    private final GuidedSpotCustomRepository guidedSpotCustomRepository;
     private final GuidedSpotRepository guidedSpotRepository;
     private final MemberRepository memberRepository;
     private final MenuRepository menuRepository;
@@ -578,34 +580,37 @@ public class SpotService {
     public SearchSuggestionListResponse fetchSearchSuggestions(final Double latitude, final Double longitude) {
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
 
-        List<SearchSuggestionResponse> recentSpotSuggestion =
-                // TODO: 250m 범위 내의 TOP5로 수정
-                guidedSpotRepository.findTopByMemberIdOrderByUpdatedAtDesc(memberEntity.getId())
-                        .flatMap(recentGuidedSpot -> spotRepository.findById(recentGuidedSpot.getSpotId()))
-                        .map(spotDtoMapper::toSearchSuggestionResponse)
-                        .stream()
-                        .toList();
+        List<SearchSuggestionResponse> recentSpotSuggestion = guidedSpotCustomRepository.findRecentGuidedSpotSuggestions(
+                memberEntity.getId(),
+                latitude,
+                longitude,
+                SUGGESTION_RADIUS,
+                SUGGESTION_LIMIT
+        );
 
-        List<SearchSuggestionResponse> nearestSpotList =
-                findNearestSpotList(longitude, latitude, WALKING_RADIUS_30_MIN, SUGGESTION_LIMIT);
+        if (recentSpotSuggestion.size() < 5) {
+            int needed = 5 - recentSpotSuggestion.size();
 
-        // Set을 통한 필터링 성능 향상
-        Set<Long> recentSpotIds = recentSpotSuggestion.stream()
-                .map(SearchSuggestionResponse::spotId)
-                .collect(Collectors.toSet());
+            List<SearchSuggestionResponse> nearestSpotList =
+                    findNearestSpotList(longitude, latitude, SUGGESTION_RADIUS, SUGGESTION_LIMIT);
 
-        List<SearchSuggestionResponse> filteredNearestSpotList = nearestSpotList.stream()
-                .filter(nearestSpot -> !recentSpotIds.contains(nearestSpot.spotId()))
-                .toList();
+            // Set을 통한 필터링 성능 향상
+            Set<Long> existingSpotIds = recentSpotSuggestion.stream()
+                    .map(SearchSuggestionResponse::spotId)
+                    .collect(Collectors.toSet());
 
-        List<SearchSuggestionResponse> combinedSuggestionList = Stream.concat(
-                        recentSpotSuggestion.stream(),
-                        filteredNearestSpotList.stream()
-                )
-                .limit(SUGGESTION_LIMIT)
-                .toList();
+            List<SearchSuggestionResponse> filteredNearestSpotList = nearestSpotList.stream()
+                    .filter(nearestSpot -> !existingSpotIds.contains(nearestSpot.spotId()))
+                    .limit(needed)
+                    .toList();
 
-        return new SearchSuggestionListResponse(combinedSuggestionList);
+            recentSpotSuggestion = Stream.concat(
+                    recentSpotSuggestion.stream(),
+                    filteredNearestSpotList.stream()
+            ).toList();
+        }
+
+        return new SearchSuggestionListResponse(recentSpotSuggestion);
     }
 
     // TODO: limit 없는 메서드로부터 분기하도록 리팩토링
@@ -626,15 +631,18 @@ public class SpotService {
         if (keyword == null || keyword.trim().isEmpty()) {
             return new SearchSpotListResponse(Collections.emptyList());
         }
-      
+
         List<SpotEntity> spotEntityList = spotRepository.findTop10ByNameStartingWithIgnoreCase(keyword);
-      
+
         if (spotEntityList.size() < SEARCH_LIMIT) {
-            List<SpotEntity> additionalSpots =
-              spotRepository.findByNameContainingWithLimitIgnoreCase(keyword, SEARCH_LIMIT - spotEntityList.size());
+            List<SpotEntity> additionalSpots = spotRepository.findByNameContainingWithLimitIgnoreCase(
+                    keyword, SEARCH_LIMIT - spotEntityList.size()
+            );
+
             Set<Long> existingSpotIds = spotEntityList.stream()
                     .map(SpotEntity::getId)
                     .collect(Collectors.toSet());
+
             spotEntityList.addAll(
                     additionalSpots.stream()
                             .filter(additionalSpot -> !existingSpotIds.contains(additionalSpot.getId()))

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -588,8 +588,8 @@ public class SpotService {
                 SUGGESTION_LIMIT
         );
 
-        if (recentSpotSuggestion.size() < 5) {
-            int needed = 5 - recentSpotSuggestion.size();
+        if (recentSpotSuggestion.size() < SUGGESTION_LIMIT) {
+            int needed = SUGGESTION_LIMIT - recentSpotSuggestion.size();
 
             List<SearchSuggestionResponse> nearestSpotList =
                     findNearestSpotList(longitude, latitude, SUGGESTION_RADIUS, SUGGESTION_LIMIT);


### PR DESCRIPTION
# 💡 Issue
- resolved: #66 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
`가장 최근 길 안내 장소 1곳 + 가장 가까운 장소 4곳(2km 이내)`로 최대 5개의 추천 검색어를 보여주는 로직에서 (5개 미만이면 있는 거만 보여줌)

-> `가장 최근 길 안내 장소 최대 5곳(250m 이내)을 기준으로 5개 미만이면 그만큼 가장 가까운 장소(250m 이내)로 채우는 로직`으로 수정했습니다. (여기서도 5개 미만일 경우 있는 것들만 보여주기 때문에 사용자 위치에 따라 추천 검색어가 없을 수도 있습니다)