### PR TITLE
[FEAT/#73] 토큰 재발급 / 로그아웃 / 회원 탈퇴 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ dependencies {
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Caffeine Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/acon/server/global/auth/CacheConfig.java
+++ b/src/main/java/com/acon/server/global/auth/CacheConfig.java
@@ -11,6 +11,7 @@ import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+// TODO: 어노테이션을 활용하여 리팩
 @Configuration
 @EnableCaching
 public class CacheConfig {

--- a/src/main/java/com/acon/server/global/auth/CacheConfig.java
+++ b/src/main/java/com/acon/server/global/auth/CacheConfig.java
@@ -1,0 +1,37 @@
+package com.acon.server.global.auth;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Value("${jwt.refresh-token-expire-time}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME;
+
+    @Bean
+    public CacheManager cacheManager() {
+
+        // 최대 용량 설정을 따로 진행하지 않음. 메모리 부족 문제 주의 필요
+        Caffeine<Object, Object> caffeineBuilder = Caffeine.newBuilder()
+                .expireAfterWrite(REFRESH_TOKEN_EXPIRATION_TIME, TimeUnit.MILLISECONDS);
+
+        CaffeineCache refreshTokenCache = new CaffeineCache(
+                "refreshTokenCache",
+                caffeineBuilder.build()
+        );
+
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(Collections.singletonList(refreshTokenCache));
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/acon/server/global/auth/CacheConfig.java
+++ b/src/main/java/com/acon/server/global/auth/CacheConfig.java
@@ -20,7 +20,7 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-
+        // TODO: initialCapacity, maximumSize 설정
         // 최대 용량 설정을 따로 진행하지 않음. 메모리 부족 문제 주의 필요
         Caffeine<Object, Object> caffeineBuilder = Caffeine.newBuilder()
                 .expireAfterWrite(REFRESH_TOKEN_EXPIRATION_TIME, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
@@ -160,9 +160,7 @@ public class JwtTokenProvider {
     public void deleteRefreshToken(String refreshToken) {
         Cache cache = cacheManager.getCache("refreshTokenCache");
         validateRefreshToken(refreshToken);
-        System.out.println(cache.get(refreshToken, Long.class));
         cache.evict(refreshToken);
-        System.out.println(cache.get(refreshToken, Long.class));
     }
 
 }

--- a/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
@@ -158,6 +158,7 @@ public class JwtTokenProvider {
         throw new BusinessException(ErrorType.INVALID_REFRESH_TOKEN_ERROR);
     }
 
+    // TODO: 블랙리스트 설정 필요
     public void deleteRefreshToken(String refreshToken) {
         Cache cache = cacheManager.getCache("refreshTokenCache");
         validateRefreshToken(refreshToken);

--- a/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
@@ -141,6 +141,7 @@ public class JwtTokenProvider {
                 .getBody();
     }
 
+    // TODO: cache token 관리 로직 클래스로 분리
     public void storeRefreshToken(String refreshToken, Long memberId) {
         Cache cache = cacheManager.getCache("refreshTokenCache");
         // 존재 유무만 확인하므로 빈 값

--- a/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/acon/server/global/auth/jwt/JwtTokenProvider.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +32,8 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
     private static final String MEMBER_ID = "memberId";
+
+    private final CacheManager cacheManager;
 
     @Value("${jwt.access-token-expire-time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME;
@@ -50,15 +54,18 @@ public class JwtTokenProvider {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
     }
 
-    public String issueRefreshToken() {
+    public String issueRefreshToken(Long memberId) {
         final Date now = new Date();
 
-        return Jwts.builder()
+        final String refreshToken = Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_TIME))
                 .signWith(getSigningKey())
                 .compact();
+        storeRefreshToken(refreshToken, memberId);
+
+        return refreshToken;
     }
 
     public String generateToken(
@@ -133,4 +140,29 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
     }
+
+    public void storeRefreshToken(String refreshToken, Long memberId) {
+        Cache cache = cacheManager.getCache("refreshTokenCache");
+        // 존재 유무만 확인하므로 빈 값
+        // TODO: Refresh Token key 수정
+        cache.put(refreshToken, memberId);
+    }
+
+    public Long validateRefreshToken(String refreshToken) {
+        Cache cache = cacheManager.getCache("refreshTokenCache");
+        // Intellij는 해당 조건이 항상 true라고 메세지를 띄우지만 cache.get(memberId)의 반환값이 존재하지 않을 시 null입니다!
+        if (cache.get(refreshToken) != null) {
+            return cache.get(refreshToken, Long.class);
+        }
+        throw new BusinessException(ErrorType.INVALID_REFRESH_TOKEN_ERROR);
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        Cache cache = cacheManager.getCache("refreshTokenCache");
+        validateRefreshToken(refreshToken);
+        System.out.println(cache.get(refreshToken, Long.class));
+        cache.evict(refreshToken);
+        System.out.println(cache.get(refreshToken, Long.class));
+    }
+
 }

--- a/src/main/java/com/acon/server/global/exception/ErrorType.java
+++ b/src/main/java/com/acon/server/global/exception/ErrorType.java
@@ -21,6 +21,7 @@ public enum ErrorType {
     INVALID_REQUEST_BODY_ERROR(HttpStatus.BAD_REQUEST, 40006, "유효하지 않은 Request Body입니다. 요청 형식 또는 필드를 확인하세요."),
     DATA_INTEGRITY_VIOLATION_ERROR(HttpStatus.BAD_REQUEST, 40007, "데이터 무결성 제약 조건을 위반했습니다."),
     INVALID_ACCESS_TOKEN_ERROR(HttpStatus.BAD_REQUEST, 40008, "유효하지 않은 accessToken입니다."),
+    INVALID_REFRESH_TOKEN_ERROR(HttpStatus.BAD_REQUEST, 40088, "유효하지 않은 refreshToken입니다."),
     // TODO: NonNull 필드에 null 값이 입력되었을 때 발생하는 예외 처리 추가
 
     /* 401 Unauthorized */

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -122,7 +122,7 @@ public class MemberController {
         );
     }
 
-    @PostMapping(path = "/auth/logout", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/auth/logout", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> logout(
             @Valid @RequestBody LogoutRequest request
     ) {
@@ -130,7 +130,7 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(path = "/auth/reissue", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/auth/reissue", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ReissueTokenResponse> reissueToken(
             @Valid @RequestBody ReissueTokenRequest request
     ) {
@@ -139,7 +139,7 @@ public class MemberController {
         );
     }
 
-    @PostMapping(path = "/members/withdrawal", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/members/withdrawal", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> postWithdrawal(
             @Valid @RequestBody WithdrawalReasonRequest request
     ) {

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -2,12 +2,16 @@ package com.acon.server.member.api.controller;
 
 import com.acon.server.member.api.request.GuidedSpotRequest;
 import com.acon.server.member.api.request.LoginRequest;
+import com.acon.server.member.api.request.LogoutRequest;
 import com.acon.server.member.api.request.MemberAreaRequest;
 import com.acon.server.member.api.request.PreferenceRequest;
+import com.acon.server.member.api.request.ReissueTokenRequest;
+import com.acon.server.member.api.request.WithdrawalReasonRequest;
 import com.acon.server.member.api.response.AcornCountResponse;
 import com.acon.server.member.api.response.LoginResponse;
 import com.acon.server.member.api.response.MemberAreaResponse;
 import com.acon.server.member.api.response.ProfileResponse;
+import com.acon.server.member.api.response.ReissueTokenResponse;
 import com.acon.server.member.application.service.MemberService;
 import com.acon.server.member.domain.enums.Cuisine;
 import com.acon.server.member.domain.enums.DislikeFood;
@@ -116,5 +120,30 @@ public class MemberController {
         return ResponseEntity.ok(
                 memberService.fetchProfile()
         );
+    }
+
+    @PostMapping(path = "/auth/logout", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> logout(
+            @Valid @RequestBody LogoutRequest request
+    ) {
+        memberService.logout(request.refreshToken());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(path = "/auth/reissue", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ReissueTokenResponse> reissueToken(
+            @Valid @RequestBody ReissueTokenRequest request
+    ) {
+        return ResponseEntity.ok(
+                memberService.reissueToken(request.refreshToken())
+        );
+    }
+
+    @PostMapping(path = "/members/withdrawal", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> postWithdrawal(
+            @Valid @RequestBody WithdrawalReasonRequest request
+    ) {
+        memberService.withdrawMember(request.reason());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -143,7 +143,7 @@ public class MemberController {
     public ResponseEntity<Void> postWithdrawal(
             @Valid @RequestBody WithdrawalReasonRequest request
     ) {
-        memberService.withdrawMember(request.reason());
+        memberService.withdrawMember(request.reason(), request.refreshToken());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -130,7 +130,9 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(path = "/auth/reissue", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(path = "/auth/reissue",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ReissueTokenResponse> reissueToken(
             @Valid @RequestBody ReissueTokenRequest request
     ) {

--- a/src/main/java/com/acon/server/member/api/request/LogoutRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/LogoutRequest.java
@@ -3,7 +3,7 @@ package com.acon.server.member.api.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record LogoutRequest(
-        @NotBlank(message = "refreshToken은 필수입니다.")
+        @NotBlank(message = "refreshToken은 공백일 수 없습니다.")
         String refreshToken
 ) {
 

--- a/src/main/java/com/acon/server/member/api/request/LogoutRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/LogoutRequest.java
@@ -1,0 +1,10 @@
+package com.acon.server.member.api.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LogoutRequest(
+        @NotNull(message = "refreshToken은 필수입니다.")
+        String refreshToken
+) {
+
+}

--- a/src/main/java/com/acon/server/member/api/request/LogoutRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/LogoutRequest.java
@@ -1,9 +1,9 @@
 package com.acon.server.member.api.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record LogoutRequest(
-        @NotNull(message = "refreshToken은 필수입니다.")
+        @NotBlank(message = "refreshToken은 필수입니다.")
         String refreshToken
 ) {
 

--- a/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
@@ -3,7 +3,7 @@ package com.acon.server.member.api.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record ReissueTokenRequest(
-        @NotBlank(message = "refreshToken은 필수입니다.")
+        @NotBlank(message = "refreshToken은 공백일 수 없습니다.")
         String refreshToken
 ) {
 

--- a/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
@@ -1,10 +1,10 @@
 package com.acon.server.member.api.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 public record ReissueTokenRequest(
 
-        @NotNull(message = "refreshToken은 필수입니다.")
+        @NotBlank(message = "refreshToken은 필수입니다.")
         String refreshToken
 ) {
 

--- a/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
@@ -1,0 +1,11 @@
+package com.acon.server.member.api.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReissueTokenRequest(
+
+        @NotNull(message = "refreshToken은 필수입니다.")
+        String refreshToken
+) {
+
+}

--- a/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/ReissueTokenRequest.java
@@ -3,7 +3,6 @@ package com.acon.server.member.api.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record ReissueTokenRequest(
-
         @NotBlank(message = "refreshToken은 필수입니다.")
         String refreshToken
 ) {

--- a/src/main/java/com/acon/server/member/api/request/WithdrawalReasonRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/WithdrawalReasonRequest.java
@@ -1,0 +1,10 @@
+package com.acon.server.member.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawalReasonRequest(
+        @NotBlank(message = "탈퇴 이유는 공백일 수 없습니다.")
+        String reason
+) {
+
+}

--- a/src/main/java/com/acon/server/member/api/request/WithdrawalReasonRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/WithdrawalReasonRequest.java
@@ -4,7 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 
 public record WithdrawalReasonRequest(
         @NotBlank(message = "탈퇴 이유는 공백일 수 없습니다.")
-        String reason
+        String reason,
+        @NotBlank(message = "refreshToken은 공백일 수 없습니다.")
+        String refreshToken
 ) {
 
 }

--- a/src/main/java/com/acon/server/member/api/response/ReissueTokenResponse.java
+++ b/src/main/java/com/acon/server/member/api/response/ReissueTokenResponse.java
@@ -1,0 +1,14 @@
+package com.acon.server.member.api.response;
+
+public record ReissueTokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static ReissueTokenResponse of(
+            final String accessToken,
+            final String refreshToken
+    ) {
+        return new ReissueTokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -255,10 +255,13 @@ public class MemberService {
     }
 
     @Transactional
-    public void withdrawMember(String reason) {
+    public void withdrawMember(String reason, String refreshToken) {
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
 
         memberRepository.deleteById(memberEntity.getId());
+        jwtTokenProvider.deleteRefreshToken(refreshToken);
+        // TODO: 엑세스 토큰 블랙리스트
+
         withdrawalReasonRepository.save(
                 WithdrawalReasonEntity.builder()
                         .reason(reason)

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -262,7 +262,6 @@ public class MemberService {
     @Transactional
     public void withdrawMember(String reason) {
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
-        memberRepository.findByIdOrElseThrow(memberEntity.getId());
 
         memberRepository.deleteById(memberEntity.getId());
         withdrawalReasonRepository.save(

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -246,11 +246,6 @@ public class MemberService {
         Long memberId = jwtTokenProvider.validateRefreshToken(refreshToken);
         memberRepository.findByIdOrElseThrow(memberId);
 
-        MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
-        if (!memberEntity.getId().equals(jwtTokenProvider.validateRefreshToken(refreshToken))) {
-            throw new BusinessException(ErrorType.INVALID_ACCESS_TOKEN_ERROR);
-        }
-
         jwtTokenProvider.deleteRefreshToken(refreshToken);
 
         MemberAuthentication memberAuthentication = new MemberAuthentication(memberId, null, null);

--- a/src/main/java/com/acon/server/member/infra/entity/WithdrawalReasonEntity.java
+++ b/src/main/java/com/acon/server/member/infra/entity/WithdrawalReasonEntity.java
@@ -1,0 +1,36 @@
+package com.acon.server.member.infra.entity;
+
+import com.acon.server.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "withdrawal_reason")
+public class WithdrawalReasonEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reason", nullable = false)
+    private String reason;
+
+    @Builder
+    public WithdrawalReasonEntity(
+            Long id,
+            String reason
+    ) {
+        this.id = id;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/acon/server/member/infra/repository/WithdrawalReasonRepository.java
+++ b/src/main/java/com/acon/server/member/infra/repository/WithdrawalReasonRepository.java
@@ -1,0 +1,8 @@
+package com.acon.server.member.infra.repository;
+
+import com.acon.server.member.infra.entity.WithdrawalReasonEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WithdrawalReasonRepository extends JpaRepository<WithdrawalReasonEntity, Long> {
+
+}


### PR DESCRIPTION
# 💡 Issue
- resolved: #73

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
<img width="701" alt="image" src="https://github.com/user-attachments/assets/5ce271ef-659c-4d4e-b648-fd2082efae5e" />


# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->

### 1. 로그인
login 시 캐시에  refreshToken, memberId를 key,value로 저장합니다

### 2. 로그아웃 
로그아웃 시에는 access token 과 refresh token을 전달 받습니다
1. access token에서 추출한 memberId와 cache에 refreshToken과 같이 저장된 memberId가 일치하지 않으면 오류를 반환합니다.
2. refreshToken이 cache에 저장되어있는지 확인하고 삭제를 합니다!

### 3. 재발급
1. refresh token이 캐시에 존재하는지 확인, 캐시에 저장된 memberId가 DB에도 존재하는지 확인합니다
2. 이후 기존 존재하는 refreshToken을 삭제하고 accessToken,refreshToken 새롭게 발급합니다

### 4. 회원 탈퇴
멤버 객체가 존재하면 삭제하고, withdrawal_reason에 저장합니다!
해당 테이블은 단순히 한 번 데이터를 저장하기 위한 목적이므로 따로 도메인 엔티티를 구현하진 않았습니다 Mapper도요!
