### PR TITLE
[REFACTOR/#79] 온보딩 API PUT으로 변경

### DIFF
--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -32,6 +32,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -86,8 +87,8 @@ public class MemberController {
         return ResponseEntity.ok(new AreaResponse(area));
     }
 
-    @PostMapping(path = "/member/preference", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> postPreference(
+    @PutMapping(path = "/member/preference", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> putPreference(
             @Valid @RequestBody final PreferenceRequest request
     ) {
         List<DislikeFood> dislikeFoodList = request.dislikeFoodList().stream().map(DislikeFood::fromValue).toList();
@@ -96,7 +97,7 @@ public class MemberController {
         SpotStyle favoriteSpotStyle = SpotStyle.fromValue(request.favoriteSpotStyle());
         List<FavoriteSpot> favoriteSpotRank = request.favoriteSpotRank().stream().map(FavoriteSpot::fromValue).toList();
 
-        memberService.createPreference(dislikeFoodList, favoriteCuisineList, favoriteSpotType, favoriteSpotStyle,
+        memberService.upsertPreference(dislikeFoodList, favoriteCuisineList, favoriteSpotType, favoriteSpotStyle,
                 favoriteSpotRank);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -177,7 +177,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void createPreference(
+    public void upsertPreference(
             final List<DislikeFood> dislikeFoodList,
             final List<Cuisine> favoriteCuisineList,
             final SpotType favoriteSpotType,


### PR DESCRIPTION
# 💡 Issue
- resolved: #79 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 온보딩 API HTTP 메서드를 PUT으로 변경했습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 본 API가 기존 `POST - 온보딩` API를 완벽히 대체 가능하다고 판단하여 (`UPSERT` 중 `INSERT`에서 해당 API를 이미 포함),
해당 POST API의 존재 의의가 없다고 생각해 삭제하고 해당 자리를 본 API가 담당할 수 있게 HTTP 메서드만 `PUT`으로 수정하였습니다.