### PR TITLE
[FEAT/#90] 인증 동네 삭제 API 구현

### DIFF
--- a/src/main/java/com/acon/server/global/exception/ErrorType.java
+++ b/src/main/java/com/acon/server/global/exception/ErrorType.java
@@ -52,6 +52,10 @@ public enum ErrorType {
     INVALID_IMAGE_TYPE_ERROR(HttpStatus.BAD_REQUEST, 40045, "유효하지 않은 imageType입니다."),
     INVALID_NICKNAME_ERROR(HttpStatus.BAD_REQUEST, 40051, "닉네임이 조건을 만족하지 않습니다."),
     INVALID_BIRTH_DATE_ERROR(HttpStatus.BAD_REQUEST, 40053, "유효하지 않은 생년월일입니다."),
+    INVALID_VERIFIED_AREA_ERROR(HttpStatus.BAD_REQUEST, 40054, "유효하지 않은 인증 동네입니다."),
+
+    /* 404 Not Found */
+    NOT_FOUND_VERIFIED_AREA_ERROR(HttpStatus.NOT_FOUND, 40404, "존재하지 않는 인증 동네입니다."),
 
     /* 409 Conflict */
     DUPLICATED_NICKNAME_ERROR(HttpStatus.CONFLICT, 40901, "이미 사용 중인 닉네임입니다."),

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -27,13 +27,16 @@ import com.acon.server.spot.domain.enums.SpotType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -70,7 +73,6 @@ public class MemberController {
     public ResponseEntity<VerifiedAreaResponse> postVerifiedArea(
             @Valid @RequestBody final VerifiedAreaRequest request
     ) {
-
         return ResponseEntity.ok(
                 memberService.createVerifiedArea(request.latitude(), request.longitude())
         );
@@ -79,10 +81,19 @@ public class MemberController {
     @GetMapping(path = "/members/verified-areas", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VerifiedAreaListResponse> getVerifiedAreaList(
     ) {
-
         return ResponseEntity.ok(
                 memberService.fetchVerifiedAreaList()
         );
+    }
+
+    @DeleteMapping(path = "/members/verified-areas/{verifiedAreaId}")
+    public ResponseEntity<Void> deleteVerifiedArea(
+            @Positive(message = "verifiedAreaId는 양수여야 합니다.")
+            @PathVariable(name = "verifiedAreaId") final Long verifiedAreaId
+    ) {
+        memberService.deleteVerifiedArea(verifiedAreaId);
+
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping(path = "/area", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/acon/server/member/infra/repository/MemberRepository.java
+++ b/src/main/java/com/acon/server/member/infra/repository/MemberRepository.java
@@ -14,7 +14,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
     boolean existsByNickname(String nickname);
 
     default MemberEntity findByIdOrElseThrow(Long id) {
-        return findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorType.NOT_FOUND_MEMBER_ERROR));
+        return findById(id).orElseThrow(
+                () -> new BusinessException(ErrorType.NOT_FOUND_MEMBER_ERROR)
+        );
     }
 }

--- a/src/main/java/com/acon/server/member/infra/repository/VerifiedAreaRepository.java
+++ b/src/main/java/com/acon/server/member/infra/repository/VerifiedAreaRepository.java
@@ -1,5 +1,7 @@
 package com.acon.server.member.infra.repository;
 
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
 import com.acon.server.member.infra.entity.VerifiedAreaEntity;
 import java.util.List;
 import java.util.Optional;
@@ -7,11 +9,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VerifiedAreaRepository extends JpaRepository<VerifiedAreaEntity, Long> {
 
+    long countByMemberId(Long memberId);
+
+    boolean existsByMemberId(Long memberId);
+
     boolean existsByMemberIdAndName(Long memberId, String name);
+
+    Optional<VerifiedAreaEntity> findById(Long id);
 
     Optional<VerifiedAreaEntity> findByMemberIdAndName(Long memberId, String name);
 
-    List<VerifiedAreaEntity> findAllByMemberId(Long memberId);
+    default VerifiedAreaEntity findByIdOrElseThrow(Long id) {
+        return findById(id).orElseThrow(
+                () -> new BusinessException(ErrorType.NOT_FOUND_VERIFIED_AREA_ERROR)
+        );
+    }
 
-    boolean existsByMemberId(Long memberId);
+    List<VerifiedAreaEntity> findAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #90 

# 📸 Screenshot
<!-- 필요 시 사진, 동영상 등을 첨부해 주세요
ex) 포스트맨, 스웨거, 로그 등 -->
<img width="921" alt="image" src="https://github.com/user-attachments/assets/0d1d6b72-4fc8-426e-a785-4a87a57af451" />

<img width="922" alt="image" src="https://github.com/user-attachments/assets/c2b7c61e-9564-443e-908c-3cc44aa1d7f6" />

<img width="915" alt="image" src="https://github.com/user-attachments/assets/7adf91ad-f99c-415f-aff7-0325554d4757" />

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 인증 동네 삭제 API를 구현했습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 인증 동네 개수 셀 때 `MemberId`에 해당하는 `VerifiedAreaEntity`들을 `findAll`해서 `List size`를 계산하는 방식에서 JPA 메서드 중 `countBy`를 사용하는 방식으로 변경했습니다.