### PR TITLE
[FEAT/#92] 테스트 계정 위치 정보 강제 할당 및 서비스 미제공 지역에서 액세스 시 예외 처리 추가

### DIFF
--- a/src/main/java/com/acon/server/global/exception/ErrorType.java
+++ b/src/main/java/com/acon/server/global/exception/ErrorType.java
@@ -74,6 +74,7 @@ public enum ErrorType {
 
     /* 404 Not Found */
     NOT_FOUND_SPOT_ERROR(HttpStatus.NOT_FOUND, 40403, "존재하지 않는 장소입니다."),
+    UNAVAILABLE_SERVICE_AREA_ERROR(HttpStatus.NOT_FOUND, 40405, "서비스를 제공하지 않는 지역입니다."),
 
     /* 500 Internal Server Error */
     NAVER_MAPS_GEOCODING_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50003, "Naver Maps GeoCoding API 호출에 실패했습니다."),

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -25,8 +25,7 @@ import com.acon.server.member.domain.enums.SocialType;
 import com.acon.server.member.domain.enums.SpotStyle;
 import com.acon.server.spot.domain.enums.SpotType;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -104,11 +103,9 @@ public class MemberController {
 
     @GetMapping(path = "/area", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<AreaResponse> getArea(
-            @DecimalMin(value = "33.1", message = "위도는 최소 33.1°N 이상이어야 합니다.(대한민국 기준)")
-            @DecimalMax(value = "38.6", message = "위도는 최대 38.6°N 이하이어야 합니다.(대한민국 기준)")
+            @NotNull(message = "위도는 필수입니다.")
             @Validated @RequestParam(name = "latitude") final Double latitude,
-            @DecimalMin(value = "124.6", message = "경도는 최소 124.6°E 이상이어야 합니다.(대한민국 기준)")
-            @DecimalMax(value = "131.9", message = "경도는 최대 131.9°E 이하이어야 합니다.(대한민국 기준)")
+            @NotNull(message = "경도는 필수입니다.")
             @Validated @RequestParam(name = "longitude") final Double longitude
     ) {
         if (memberService.checkTestUser()) {

--- a/src/main/java/com/acon/server/member/api/controller/MemberController.java
+++ b/src/main/java/com/acon/server/member/api/controller/MemberController.java
@@ -73,6 +73,12 @@ public class MemberController {
     public ResponseEntity<VerifiedAreaResponse> postVerifiedArea(
             @Valid @RequestBody final VerifiedAreaRequest request
     ) {
+        if (memberService.checkTestUser()) {
+            return ResponseEntity.ok(
+                    memberService.createVerifiedArea(37.559115, 126.921976)
+            );
+        }
+
         return ResponseEntity.ok(
                 memberService.createVerifiedArea(request.latitude(), request.longitude())
         );
@@ -105,9 +111,15 @@ public class MemberController {
             @DecimalMax(value = "131.9", message = "경도는 최대 131.9°E 이하이어야 합니다.(대한민국 기준)")
             @Validated @RequestParam(name = "longitude") final Double longitude
     ) {
-        String area = memberService.fetchMemberArea(latitude, longitude);
+        if (memberService.checkTestUser()) {
+            return ResponseEntity.ok(
+                    memberService.fetchMemberArea(37.559115, 126.921976)
+            );
+        }
 
-        return ResponseEntity.ok(new AreaResponse(area));
+        return ResponseEntity.ok(
+                memberService.fetchMemberArea(latitude, longitude)
+        );
     }
 
     @PutMapping(path = "/members/preference", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/acon/server/member/api/request/VerifiedAreaRequest.java
+++ b/src/main/java/com/acon/server/member/api/request/VerifiedAreaRequest.java
@@ -1,8 +1,11 @@
 package com.acon.server.member.api.request;
 
-// TODO: validation 추가
+import jakarta.validation.constraints.NotNull;
+
 public record VerifiedAreaRequest(
+        @NotNull(message = "위도는 필수입니다.")
         Double latitude,
+        @NotNull(message = "경도는 필수입니다.")
         Double longitude
 ) {
 

--- a/src/main/java/com/acon/server/member/api/response/AreaResponse.java
+++ b/src/main/java/com/acon/server/member/api/response/AreaResponse.java
@@ -4,4 +4,7 @@ public record AreaResponse(
         String area
 ) {
 
+    public static AreaResponse of(String area) {
+        return new AreaResponse(area);
+    }
 }

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,10 +85,14 @@ public class MemberService {
     // TODO: 네이밍 변경
     private final GoogleSocialService googleSocialService;
     private final AppleAuthAdapter appleAuthService;
-
     private final NaverMapsAdapter naverMapsAdapter;
-
     private final S3Adapter s3Adapter;
+
+    @Value("${google.test-account-1}")
+    private String testAccount1;
+
+    @Value("${google.test-account-2}")
+    private String testAccount2;
 
     // TODO: 메서드 순서 정리, TRANSACTION 설정, mapper 사용
     // TODO: @Valid 거친 건 원시타입으로 받기
@@ -481,6 +486,14 @@ public class MemberService {
                         .reason(reason)
                         .build()
         );
+    }
+
+    // TODO: 순환 참조 방지를 위해 같은 메서드를 재선언했으므로, 추후 Facade 패턴을 통한 리팩토링 필요
+    @Transactional(readOnly = true)
+    public boolean checkTestUser() {
+        MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
+
+        return memberEntity.getSocialId().equals(testAccount1) || memberEntity.getSocialId().equals(testAccount2);
     }
 
     // TODO: 최근 길 안내 장소 지우는 스케줄러 추가

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -8,6 +8,7 @@ import com.acon.server.global.exception.ErrorType;
 import com.acon.server.global.external.maps.NaverMapsAdapter;
 import com.acon.server.global.external.s3.S3Adapter;
 import com.acon.server.member.api.response.AcornCountResponse;
+import com.acon.server.member.api.response.AreaResponse;
 import com.acon.server.member.api.response.LoginResponse;
 import com.acon.server.member.api.response.PreSignedUrlResponse;
 import com.acon.server.member.api.response.ProfileResponse;
@@ -66,6 +67,10 @@ public class MemberService {
     private static final DateTimeFormatter BIRTH_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
     private static final int MIN_VERIFIED_AREA_SIZE = 1;
     private static final int MAX_VERIFIED_AREA_SIZE = 5;
+    private static final double MIN_LATITUDE = 33.1;
+    private static final double MAX_LATITUDE = 38.6;
+    private static final double MIN_LONGITUDE = 124.6;
+    private static final double MAX_LONGITUDE = 131.9;
 
     private final GuidedSpotRepository guidedSpotRepository;
     private final MemberRepository memberRepository;
@@ -165,9 +170,13 @@ public class MemberService {
 
     @Transactional
     public VerifiedAreaResponse createVerifiedArea(
-            final Double latitude,
-            final Double longitude
+            final double latitude,
+            final double longitude
     ) {
+        if (isOutOfServiceArea(latitude, longitude)) {
+            throw new BusinessException(ErrorType.UNAVAILABLE_SERVICE_AREA_ERROR);
+        }
+
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
 
         if (verifiedAreaRepository.countByMemberId(memberEntity.getId()) >= MAX_VERIFIED_AREA_SIZE) {
@@ -239,11 +248,13 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public String fetchMemberArea(
-            final Double latitude,
-            final Double longitude
+    public AreaResponse fetchMemberArea(
+            final double latitude,
+            final double longitude
     ) {
-        return naverMapsAdapter.getReverseGeoCodingResult(latitude, longitude);
+        String area = naverMapsAdapter.getReverseGeoCodingResult(latitude, longitude);
+
+        return AreaResponse.of(area);
     }
 
     @Transactional
@@ -494,6 +505,14 @@ public class MemberService {
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
 
         return memberEntity.getSocialId().equals(testAccount1) || memberEntity.getSocialId().equals(testAccount2);
+    }
+
+    private boolean isOutOfServiceArea(
+            final double latitude,
+            final double longitude
+    ) {
+        return latitude < MIN_LATITUDE || latitude > MAX_LATITUDE ||
+                longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE;
     }
 
     // TODO: 최근 길 안내 장소 지우는 스케줄러 추가

--- a/src/main/java/com/acon/server/review/api/request/ReviewRequest.java
+++ b/src/main/java/com/acon/server/review/api/request/ReviewRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record ReviewRequest(
-        @NotNull(message = "userId는 필수입니다.")
+        @NotNull(message = "spotId는 필수입니다.")
         @Positive(message = "spotId는 양수여야 합니다.")
         Long spotId,
         @NotNull(message = "acornCount는 필수입니다.")

--- a/src/main/java/com/acon/server/spot/api/controller/SpotController.java
+++ b/src/main/java/com/acon/server/spot/api/controller/SpotController.java
@@ -9,8 +9,7 @@ import com.acon.server.spot.api.response.SpotListResponse;
 import com.acon.server.spot.api.response.VerifiedSpotResponse;
 import com.acon.server.spot.application.service.SpotService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -39,11 +38,16 @@ public class SpotController {
     public ResponseEntity<SpotListResponse> getRecommendedSpotList(
             @Valid @RequestBody final SpotListRequest request
     ) {
-        // TODO: QA를 위한 임시 위치 정보 할당-1, 추후 삭제 요망
-        SpotListRequest spotListRequest = new SpotListRequest(37.559115, 126.921976, request.condition());
+        if (spotService.checkTestUser()) {
+            return ResponseEntity.ok(
+                    spotService.fetchRecommendedSpotList(
+                            new SpotListRequest(37.559115, 126.921976, request.condition())
+                    )
+            );
+        }
 
         return ResponseEntity.ok(
-                spotService.fetchRecommendedSpotList(spotListRequest)
+                spotService.fetchRecommendedSpotList(request)
         );
     }
 
@@ -69,13 +73,16 @@ public class SpotController {
 
     @GetMapping(path = "/search-suggestions", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SearchSuggestionListResponse> getSearchSuggestions(
-            @DecimalMin(value = "33.1", message = "위도는 최소 33.1°N 이상이어야 합니다.(대한민국 기준)")
-            @DecimalMax(value = "38.6", message = "위도는 최대 38.6°N 이하이어야 합니다.(대한민국 기준)")
-            @Validated @RequestParam(name = "latitude") final Double latitude,
-            @DecimalMin(value = "124.6", message = "경도는 최소 124.6°E 이상이어야 합니다.(대한민국 기준)")
-            @DecimalMax(value = "131.9", message = "경도는 최대 131.9°E 이하이어야 합니다.(대한민국 기준)")
-            @Validated @RequestParam(name = "longitude") final Double longitude
+            @NotNull(message = "위도는 필수입니다.")
+            @Validated @RequestParam(name = "latitude") Double latitude,
+            @NotNull(message = "경도는 필수입니다.")
+            @Validated @RequestParam(name = "longitude") Double longitude
     ) {
+        if (spotService.checkTestUser()) {
+            latitude = 37.559115;
+            longitude = 126.921976;
+        }
+
         return ResponseEntity.ok(
                 spotService.fetchSearchSuggestions(latitude, longitude)
         );
@@ -99,9 +106,13 @@ public class SpotController {
             @Validated @RequestParam(name = "longitude") final Double longitude,
             @Validated @RequestParam(name = "latitude") final Double latitude
     ) {
-        // TODO: QA를 위한 임시 위치 정보 할당-2, 추후 삭제 요망
+        if (spotService.checkTestUser()) {
+            latitude = 37.559115;
+            longitude = 126.921976;
+        }
+
         return ResponseEntity.ok(
-                new VerifiedSpotResponse(spotService.verifySpot(spotId, 126.921976, 37.559115))
+                new VerifiedSpotResponse(spotService.verifySpot(spotId, latitude, longitude))
         );
     }
 }

--- a/src/main/java/com/acon/server/spot/api/controller/SpotController.java
+++ b/src/main/java/com/acon/server/spot/api/controller/SpotController.java
@@ -53,6 +53,7 @@ public class SpotController {
 
     @GetMapping(path = "/spots/{spotId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SpotDetailResponse> getSpotDetail(
+            @NotNull(message = "spotId는 필수입니다.")
             @Positive(message = "spotId는 양수여야 합니다.")
             @Validated @PathVariable(name = "spotId") final Long spotId
     ) {
@@ -63,6 +64,7 @@ public class SpotController {
 
     @GetMapping(path = "/spots/{spotId}/menus", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<MenuListResponse> getMenus(
+            @NotNull(message = "spotId는 필수입니다.")
             @Positive(message = "spotId는 양수여야 합니다.")
             @Validated @PathVariable(name = "spotId") final Long spotId
     ) {
@@ -101,10 +103,13 @@ public class SpotController {
     // TODO: 메서드 네이밍 수정 필요
     @GetMapping(path = "/spots/verify", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<VerifiedSpotResponse> verifySpot(
+            @NotNull(message = "spotId는 필수입니다.")
             @Positive(message = "spotId는 양수여야 합니다.")
             @Validated @RequestParam(name = "spotId") final Long spotId,
-            @Validated @RequestParam(name = "longitude") final Double longitude,
-            @Validated @RequestParam(name = "latitude") final Double latitude
+            @NotNull(message = "위도는 필수입니다.")
+            @Validated @RequestParam(name = "latitude") Double latitude,
+            @NotNull(message = "경도는 필수입니다.")
+            @Validated @RequestParam(name = "longitude") Double longitude
     ) {
         if (spotService.checkTestUser()) {
             latitude = 37.559115;

--- a/src/main/java/com/acon/server/spot/api/request/SpotListRequest.java
+++ b/src/main/java/com/acon/server/spot/api/request/SpotListRequest.java
@@ -1,27 +1,22 @@
 package com.acon.server.spot.api.request;
 
-import jakarta.validation.constraints.DecimalMax;
-import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 
 public record SpotListRequest(
         @NotNull(message = "위도는 필수입니다.")
-        @DecimalMin(value = "33.1", message = "위도는 최소 33.1°N 이상이어야 합니다.(대한민국 기준)")
-        @DecimalMax(value = "38.6", message = "위도는 최대 38.6°N 이하이어야 합니다.(대한민국 기준)")
         Double latitude,
         @NotNull(message = "경도는 필수입니다.")
-        @DecimalMin(value = "124.6", message = "경도는 최소 124.6°E 이상이어야 합니다.(대한민국 기준)")
-        @DecimalMax(value = "131.9", message = "경도는 최대 131.9°E 이하이어야 합니다.(대한민국 기준)")
         Double longitude,
         @NotNull(message = "상세 조건은 필수입니다.")
-        Condition condition
+        @Valid Condition condition
 ) {
 
     public record Condition(
             String spotType,
-            List<Filter> filterList,
+            @Valid List<Filter> filterList,
             @NotNull(message = "도보 가능 거리는 필수입니다.")
             @Positive(message = "도보 가능 거리는 양수여야 합니다.")
             Integer walkingTime,

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -73,6 +73,10 @@ public class SpotService {
     private static final int SUGGESTION_LIMIT = 5;
     private static final int VERIFICATION_DISTANCE = 250;
     private static final int SEARCH_LIMIT = 10;
+    private static final double MIN_LATITUDE = 33.1;
+    private static final double MAX_LATITUDE = 38.6;
+    private static final double MIN_LONGITUDE = 124.6;
+    private static final double MAX_LONGITUDE = 131.9;
 
     private final GuidedSpotCustomRepository guidedSpotCustomRepository;
     private final MemberRepository memberRepository;
@@ -139,6 +143,9 @@ public class SpotService {
 
     @Transactional(readOnly = true)
     public SpotListResponse fetchRecommendedSpotList(final SpotListRequest request) {
+        if (isOutOfServiceArea(request.latitude(), request.longitude())) {
+            throw new BusinessException(ErrorType.UNAVAILABLE_SERVICE_AREA_ERROR);
+        }
 
         if (principalHandler.isGuestUser()) { // TODO: 메서드화 (게스트 유저와 온보딩 건너뛴 유저)
             List<SpotEntity> filteredSpotList = filterSpotList(request);
@@ -610,7 +617,14 @@ public class SpotService {
     }
 
     @Transactional(readOnly = true)
-    public SearchSuggestionListResponse fetchSearchSuggestions(final Double latitude, final Double longitude) {
+    public SearchSuggestionListResponse fetchSearchSuggestions(
+            final Double latitude,
+            final Double longitude
+    ) {
+        if (isOutOfServiceArea(latitude, longitude)) {
+            throw new BusinessException(ErrorType.UNAVAILABLE_SERVICE_AREA_ERROR);
+        }
+
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
 
         List<SearchSuggestionResponse> recentSpotSuggestion = guidedSpotCustomRepository.findRecentGuidedSpotSuggestions(
@@ -703,6 +717,10 @@ public class SpotService {
             final double latitude,
             final double longitude
     ) {
+        if (isOutOfServiceArea(latitude, longitude)) {
+            throw new BusinessException(ErrorType.UNAVAILABLE_SERVICE_AREA_ERROR);
+        }
+
         if (!spotRepository.existsById(spotId)) {
             throw new BusinessException(ErrorType.NOT_FOUND_SPOT_ERROR);
         }
@@ -721,5 +739,13 @@ public class SpotService {
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
 
         return memberEntity.getSocialId().equals(testAccount1) || memberEntity.getSocialId().equals(testAccount2);
+    }
+
+    private boolean isOutOfServiceArea(
+            final double latitude,
+            final double longitude
+    ) {
+        return latitude < MIN_LATITUDE || latitude > MAX_LATITUDE ||
+                longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE;
     }
 }

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -57,6 +57,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -89,6 +90,12 @@ public class SpotService {
     private final PrincipalHandler principalHandler;
 
     private final NaverMapsAdapter naverMapsAdapter;
+
+    @Value("${google.test-account-1}")
+    private String testAccount1;
+
+    @Value("${google.test-account-2}")
+    private String testAccount2;
 
     // 메서드 설명: 위치 정보가 없는 Spot들의 위치 정보를 업데이트한다.
     @Transactional
@@ -692,20 +699,27 @@ public class SpotService {
 
     @Transactional(readOnly = true)
     public boolean verifySpot(
-            final Long spotId,
-            final Double memberLongitude,
-            final Double memberLatitude
+            final long spotId,
+            final double latitude,
+            final double longitude
     ) {
         if (!spotRepository.existsById(spotId)) {
             throw new BusinessException(ErrorType.NOT_FOUND_SPOT_ERROR);
         }
 
-        Double distance = spotRepository.calculateDistanceFromSpot(spotId, memberLongitude, memberLatitude);
+        Double distance = spotRepository.calculateDistanceFromSpot(spotId, longitude, latitude);
 
         if (distance == null) {
             return false;
         }
 
         return distance <= VERIFICATION_DISTANCE;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkTestUser() {
+        MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getUserIdFromPrincipal());
+
+        return memberEntity.getSocialId().equals(testAccount1) || memberEntity.getSocialId().equals(testAccount2);
     }
 }

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotRepository.java
@@ -60,8 +60,8 @@ public interface SpotRepository extends JpaRepository<SpotEntity, Long> {
             WHERE s.id = :spotId
             """, nativeQuery = true)
     Double calculateDistanceFromSpot(
-            @Param("spotId") Long spotId,
-            @Param("longitude") Double longitude,
-            @Param("latitude") Double latitude
+            @Param("spotId") long spotId,
+            @Param("longitude") double longitude,
+            @Param("latitude") double latitude
     );
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #92 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 심사를 위해 테스트 계정의 위치 정보를 강제로 할당했습니다.
- 서비스 미제공 지역에서 액세스 시 예외 처리를 추가했습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 서비스에서 다른 서비스를 참조하면서 발생하게 될 순환 참조 문제를 방지하기 위해 일단 중복 메서드를 서로 다른 서비스에서 재선언했는데요, 추후 `Facade` 패턴을 활용한 별도 서비스 계층을 만드는 등 서비스 간 결합도를 줄이기 위한 리팩토링이 필요해 보입니다.