### PR TITLE
[FEAT/#94] 외부 분석 도구용 유저 고유 식별자 추가

### DIFF
--- a/src/main/java/com/acon/server/member/api/response/LoginResponse.java
+++ b/src/main/java/com/acon/server/member/api/response/LoginResponse.java
@@ -1,16 +1,18 @@
 package com.acon.server.member.api.response;
 
 public record LoginResponse(
+        String externalUUID,
         String accessToken,
         String refreshToken,
         boolean hasVerifiedArea
 ) {
 
     public static LoginResponse of(
+            final String externalUUID,
             final String accessToken,
             final String refreshToken,
             final boolean hasVerifiedArea
     ) {
-        return new LoginResponse(accessToken, refreshToken, hasVerifiedArea);
+        return new LoginResponse(externalUUID, accessToken, refreshToken, hasVerifiedArea);
     }
 }

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -29,6 +29,7 @@ import com.acon.server.member.domain.enums.FavoriteSpot;
 import com.acon.server.member.domain.enums.ImageType;
 import com.acon.server.member.domain.enums.SocialType;
 import com.acon.server.member.domain.enums.SpotStyle;
+import com.acon.server.member.domain.vo.MemberIdentifiersVO;
 import com.acon.server.member.infra.entity.GuidedSpotEntity;
 import com.acon.server.member.infra.entity.MemberEntity;
 import com.acon.server.member.infra.entity.VerifiedAreaEntity;
@@ -117,38 +118,44 @@ public class MemberService {
             throw new BusinessException(ErrorType.INVALID_SOCIAL_TYPE_ERROR);
         }
 
-        Long memberId = fetchMemberId(socialType, socialId);
-        MemberAuthentication memberAuthentication = new MemberAuthentication(memberId, null, null);
+        MemberIdentifiersVO memberIdsVO = fetchMemberIdAndExternalUUID(socialType, socialId);
+        MemberAuthentication memberAuthentication = new MemberAuthentication(memberIdsVO.memberId(), null, null);
         String accessToken = jwtTokenProvider.issueAccessToken(memberAuthentication);
-        String refreshToken = jwtTokenProvider.issueRefreshToken(memberId);
+        String refreshToken = jwtTokenProvider.issueRefreshToken(memberIdsVO.memberId());
 
-        boolean hasVerifiedArea = verifiedAreaRepository.existsByMemberId(memberId);
+        boolean hasVerifiedArea = verifiedAreaRepository.existsByMemberId(memberIdsVO.memberId());
 
-        return LoginResponse.of(accessToken, refreshToken, hasVerifiedArea);
+        return LoginResponse.of(memberIdsVO.externalUUID(), accessToken, refreshToken, hasVerifiedArea);
     }
 
-    private Long fetchMemberId(
+    private MemberIdentifiersVO fetchMemberIdAndExternalUUID(
             final SocialType socialType,
             final String socialId
     ) {
         Optional<MemberEntity> optionalMemberEntity = memberRepository.findBySocialTypeAndSocialId(socialType,
                 socialId);
+
         MemberEntity memberEntity = optionalMemberEntity.orElseGet(() ->
                 memberRepository.save(MemberEntity.builder()
                         .socialType(socialType)
                         .socialId(socialId)
-                        .leftAcornCount(25)
-                        .nickname(generateUniqueNickname())
+                        .externalUUID(generateUUID())
                         .profileImage(s3Adapter.getBasicProfileImageUrl())
+                        .nickname(generateUniqueNickname())
+                        .leftAcornCount(25)
                         .build())
         );
 
         Member member = memberMapper.toDomain(memberEntity);
 
-        return member.getId();
+        return MemberIdentifiersVO.of(member.getId(), member.getExternalUUID());
     }
 
-    public String generateUniqueNickname() {
+    private String generateUUID() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String generateUniqueNickname() {
         String nickname;
         do {
             nickname = generateRandomNickname();

--- a/src/main/java/com/acon/server/member/domain/entity/Member.java
+++ b/src/main/java/com/acon/server/member/domain/entity/Member.java
@@ -14,6 +14,7 @@ public class Member {
     private final Long id;
     private final SocialType socialType;
     private final String socialId;
+    private final String externalUUID;
 
     private Double recentLatitude;
     private Double recentLongitude;
@@ -30,6 +31,7 @@ public class Member {
             Long id,
             SocialType socialType,
             String socialId,
+            String externalUUID,
             Double recentLatitude,
             Double recentLongitude,
             String profileImage,
@@ -43,6 +45,7 @@ public class Member {
         this.id = id;
         this.socialType = socialType;
         this.socialId = socialId;
+        this.externalUUID = externalUUID;
         this.recentLatitude = recentLatitude;
         this.recentLongitude = recentLongitude;
         this.profileImage = profileImage;

--- a/src/main/java/com/acon/server/member/domain/vo/MemberIdentifiersVO.java
+++ b/src/main/java/com/acon/server/member/domain/vo/MemberIdentifiersVO.java
@@ -1,0 +1,11 @@
+package com.acon.server.member.domain.vo;
+
+public record MemberIdentifiersVO(
+        Long memberId,
+        String externalUUID
+) {
+
+    public static MemberIdentifiersVO of(Long memberId, String externalUUID) {
+        return new MemberIdentifiersVO(memberId, externalUUID);
+    }
+}

--- a/src/main/java/com/acon/server/member/infra/entity/MemberEntity.java
+++ b/src/main/java/com/acon/server/member/infra/entity/MemberEntity.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+// TODO: socialType, socialId를 unique로 묶기
 @Table(name = "member")
 public class MemberEntity extends BaseTimeEntity {
 
@@ -33,16 +34,19 @@ public class MemberEntity extends BaseTimeEntity {
     @Column(name = "social_id", nullable = false, unique = true)
     private String socialId;
 
+    @Column(name = "external_uuid", nullable = false, unique = true)
+    private String externalUUID;
+
     @Column(name = "recent_latitude")
     private Double recentLatitude;
 
     @Column(name = "recent_longitude")
     private Double recentLongitude;
 
-    @Column(name = "profile_image")
+    @Column(name = "profile_image", nullable = false)
     private String profileImage;
 
-    @Column(name = "nickname", unique = true, nullable = false)
+    @Column(name = "nickname", nullable = false, unique = true)
     private String nickname;
 
     @Column(name = "nickname_updated_at")
@@ -59,6 +63,7 @@ public class MemberEntity extends BaseTimeEntity {
             Long id,
             SocialType socialType,
             String socialId,
+            String externalUUID,
             Double recentLatitude,
             Double recentLongitude,
             String profileImage,
@@ -70,6 +75,7 @@ public class MemberEntity extends BaseTimeEntity {
         this.id = id;
         this.socialType = socialType;
         this.socialId = socialId;
+        this.externalUUID = externalUUID;
         this.recentLatitude = recentLatitude;
         this.recentLongitude = recentLongitude;
         this.profileImage = profileImage;
@@ -77,6 +83,6 @@ public class MemberEntity extends BaseTimeEntity {
         this.nicknameUpdatedAt = nicknameUpdatedAt;
         this.birthDate = birthDate;
         // TODO: 도메인 로직으로 이동
-        this.leftAcornCount = leftAcornCount != null ? leftAcornCount : 5;
+        this.leftAcornCount = leftAcornCount != null ? leftAcornCount : 25;
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #94 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 앰플리튜드, 믹스패널 등 외부 분석 도구에서 사용될 유저 고유 식별자를 유저 로그인 시 전달하고자 `member` 테이블에 해당 식별자를 보관할 필드를 하나 추가했습니다.

# 💬 To Reviewers
<!-- 리뷰어들에게 남기고 싶은 말을 적어주세요
ex) 코드 리뷰 간 참고사항, 질문 등 -->
- 기존 테이블에 없던 `column`을 추가하고 해당 `column`에 `nullable = false` 설정을 주었으므로, `NOT NULL` 제약을 주기 전에 운영 DB 기존 `row`들에 수동으로 UUID를 넣어줄 예정입니다.