### PR TITLE
[FEAT/#108] 소셜 로그인 시 취향탐색 여부 응답 추가

### DIFF
--- a/src/main/java/com/acon/server/member/api/response/LoginResponse.java
+++ b/src/main/java/com/acon/server/member/api/response/LoginResponse.java
@@ -4,15 +4,17 @@ public record LoginResponse(
         String externalUUID,
         String accessToken,
         String refreshToken,
-        Boolean hasVerifiedArea
+        Boolean hasVerifiedArea,
+        Boolean hasPreference
 ) {
 
     public static LoginResponse of(
             final String externalUUID,
             final String accessToken,
             final String refreshToken,
-            final Boolean hasVerifiedArea
+            final Boolean hasVerifiedArea,
+            final Boolean hasPreference
     ) {
-        return new LoginResponse(externalUUID, accessToken, refreshToken, hasVerifiedArea);
+        return new LoginResponse(externalUUID, accessToken, refreshToken, hasVerifiedArea, hasPreference);
     }
 }

--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -220,13 +220,15 @@ public class MemberService {
         String refreshToken = jwtTokenProvider.issueRefreshToken(memberIdsVO.memberId());
 
         boolean hasVerifiedArea = verifiedAreaRepository.existsByMemberId(memberIdsVO.memberId());
+        boolean hasPreference = preferenceRepository.existsById(memberIdsVO.memberId());
 
         // TODO: dto 파라미터 개수에 따른 컨벤션 고민 필요
         return LoginResponse.of(
                 memberIdsVO.externalUUID(),
                 accessToken,
                 refreshToken,
-                hasVerifiedArea
+                hasVerifiedArea,
+                hasPreference
         );
     }
 


### PR DESCRIPTION
# 💡 Issue
- resolved: #108 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 소셜 로그인 시 Response Body에 취향탐색 여부 필드를 추가했습니다. (기존 API 작동에 영향을 끼치는 부분은 없기에 따로 버전 분리 X)