### PR TITLE
[FEAT/#114] 화이트리스트 축소 및 공개 엔드포인트 명시 (401 루프 오류 수정)

### DIFF
--- a/src/main/java/com/acon/server/global/auth/security/SecurityConfig.java
+++ b/src/main/java/com/acon/server/global/auth/security/SecurityConfig.java
@@ -6,12 +6,15 @@ import com.acon.server.global.auth.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,12 +26,17 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     private static final String[] AUTH_WHITE_LIST = {
-            "/api/v1/auth/**",
-            "/api/v2/auth/**"
+            "/api/v1/auth/login",
+            "/api/v1/auth/reissue"
     };
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    MvcRequestMatcher.Builder mvc(HandlerMappingIntrospector introspector) {
+        return new MvcRequestMatcher.Builder(introspector);
+    }
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
@@ -39,6 +47,12 @@ public class SecurityConfig {
                 })
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_WHITE_LIST).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/app-updates").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/spots").permitAll()
+                        .requestMatchers(
+                                mvc.pattern(HttpMethod.GET, "/api/v1/spots/{spotId:\\d+}"),
+                                mvc.pattern(HttpMethod.GET, "/api/v1/spots/{spotId:\\d+}/menuboards")
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -466,7 +466,7 @@ public class SpotService {
     ) {
         if (principalHandler.isGuestUser()) {
             if (!isDeepLink) {
-                throw new BusinessException(ErrorType.NO_PRINCIPAL_ERROR);
+                throw new BusinessException(ErrorType.UN_LOGIN_ERROR);
             }
 
             return false;


### PR DESCRIPTION
# 💡 Issue
- resolved: #114 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 화이트리스트를 축소하고 공개 엔드포인트를 명시하여 액세스 토큰이 Optional인 API의 401 무한루프 에러를 수정했습니다.
- 이때 Security가 Spring MVC와 동일한 규칙(`@RequestMapping`)으로 경로를 매칭하게 해 주는 도구인 `MvcRequestMatcher.Builder`를 활용해 경로변수와 정규식 제약을 세밀하게 설정했습니다.