### PR TITLE
[FEAT/#124] 데이터 무결성 보장을 위한 복합 유니크 제약조건 추가

### DIFF
--- a/src/main/java/com/acon/server/spot/infra/entity/MenuEntity.java
+++ b/src/main/java/com/acon/server/spot/infra/entity/MenuEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-        name = "menu"
+        name = "menu",
+        uniqueConstraints = @UniqueConstraint(
+                name = "unique_menu_spot_id_name",
+                columnNames = {"spot_id", "name"}
+        )
 //        indexes = @Index(
 //                name = "idx_menu_spot_id",
 //                columnList = "spot_id"

--- a/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
+++ b/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
@@ -91,12 +91,8 @@ public class SpotEntity {
     @Column(name = "legal_dong")
     private String legalDong;
 
-    @Column(name = "applied_member_id", insertable = false, updatable = false)
+    @Column(name = "applied_member_id")
     private Long appliedMemberId;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "applied_member_id", referencedColumnName = "id")
-    private MemberEntity appliedMember;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "spot_status", length = 20, nullable = false)

--- a/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
+++ b/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
@@ -1,5 +1,6 @@
 package com.acon.server.spot.infra.entity;
 
+import com.acon.server.member.infra.entity.MemberEntity;
 import com.acon.server.spot.api.response.SearchSuggestionResponse;
 import com.acon.server.spot.domain.enums.SpotStatus;
 import com.acon.server.spot.domain.enums.SpotType;
@@ -10,11 +11,15 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,7 +48,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "spot")
+@Table(
+        name = "spot",
+        uniqueConstraints = @UniqueConstraint(
+                name = "unique_spot_name_address",
+                columnNames = {"name", "address"}
+        )
+)
 // TODO: 공간 인덱스 설정
 public class SpotEntity {
 
@@ -80,8 +91,12 @@ public class SpotEntity {
     @Column(name = "legal_dong")
     private String legalDong;
 
-    @Column(name = "applied_member_id")
+    @Column(name = "applied_member_id", insertable = false, updatable = false)
     private Long appliedMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applied_member_id", referencedColumnName = "id")
+    private MemberEntity appliedMember;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "spot_status", length = 20, nullable = false)

--- a/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
+++ b/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
@@ -1,6 +1,5 @@
 package com.acon.server.spot.infra.entity;
 
-import com.acon.server.member.infra.entity.MemberEntity;
 import com.acon.server.spot.api.response.SearchSuggestionResponse;
 import com.acon.server.spot.domain.enums.SpotStatus;
 import com.acon.server.spot.domain.enums.SpotType;
@@ -11,12 +10,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SqlResultSetMapping;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;


### PR DESCRIPTION
# 💡 Issue
- resolved: #124 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 데이터 무결성을 보장하기 위해 복합 유니크 제약조건을 추가해 Menu, Spot 테이블에 중복 데이터가 생기는 것을 방지했습니다.