### PR TITLE
[FEAT/#126] 어드민 장소 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,13 +70,19 @@ dependencies {
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    
+
     // Caffeine Cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
-    
+
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.32.9'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/acon/server/admin/api/controller/AdminController.java
+++ b/src/main/java/com/acon/server/admin/api/controller/AdminController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -71,11 +72,14 @@ public class AdminController {
             @RequestParam(name = "status", required = false) List<String> status,
             @RequestParam(name = "missingField", required = false) String missingFieldString
     ) {
-        QueryTarget queryTarget = QueryTarget.fromValue(queryTargetString);
-        List<SpotStatus> spotStatusList = status.stream()
+        QueryTarget queryTarget = queryTargetString != null ? QueryTarget.fromValue(queryTargetString) : null;
+        List<SpotStatus> spotStatusList = (status != null)
+                ? status.stream()
+                .filter(Objects::nonNull)
                 .map(SpotStatus::fromValue)
-                .toList();
-        MissingField missingField = MissingField.fromValue(missingFieldString);
+                .toList()
+                : List.of();
+        MissingField missingField = missingFieldString != null ? MissingField.fromValue(missingFieldString) : null;
 
         return ResponseEntity.ok(
                 adminService.getSpots(query, queryTarget, spotStatusList, missingField)

--- a/src/main/java/com/acon/server/admin/api/controller/AdminController.java
+++ b/src/main/java/com/acon/server/admin/api/controller/AdminController.java
@@ -2,7 +2,10 @@ package com.acon.server.admin.api.controller;
 
 import com.acon.server.admin.api.response.CsrfTokenResponse;
 import com.acon.server.admin.api.response.DashboardResponse;
+import com.acon.server.admin.api.response.SpotListResponse;
 import com.acon.server.admin.application.service.AdminService;
+import com.acon.server.admin.domain.enums.MissingField;
+import com.acon.server.admin.domain.enums.QueryTarget;
 import com.acon.server.member.api.request.PreSignedUrlRequest;
 import com.acon.server.member.api.response.PreSignedUrlResponse;
 import com.acon.server.member.application.service.MemberService;
@@ -62,72 +65,21 @@ public class AdminController {
     }
 
     @GetMapping(path = "/spots", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> getSpots(
+    public ResponseEntity<SpotListResponse> getSpots(
             @RequestParam(required = false) String query,
-            @RequestParam(required = false) String queryTarget,
-            @RequestParam(required = false) List<String> status,
-            @RequestParam(required = false) String missingField) {
+            @RequestParam(name = "queryTarget", required = false) String queryTargetString,
+            @RequestParam(name = "status", required = false) List<String> status,
+            @RequestParam(name = "missingField", required = false) String missingFieldString
+    ) {
+        QueryTarget queryTarget = QueryTarget.fromValue(queryTargetString);
+        List<SpotStatus> spotStatusList = status.stream()
+                .map(SpotStatus::fromValue)
+                .toList();
+        MissingField missingField = MissingField.fromValue(missingFieldString);
 
-        List<Map<String, Object>> spotList = List.of(
-                Map.of(
-                        "id", 1L,
-                        "userNickname", "김성민",
-                        "spotName", "커피 리브레 서교동",
-                        "spotStatus", "PENDING",
-                        "spotType", "CAFE",
-                        "updatedAt", "2025-08-06T10:00:00"
-                ),
-                Map.of(
-                        "id", 2L,
-                        "userNickname", "김시은",
-                        "spotName", "프릳츠 커피 컴퍼니 도화점",
-                        "spotStatus", "PENDING",
-                        "spotType", "CAFE",
-                        "updatedAt", "2025-08-06T10:15:00"
-                ),
-                Map.of(
-                        "id", 3L,
-                        "userNickname", "김유림",
-                        "spotName", "빈브라더스 성수동",
-                        "spotStatus", "PENDING",
-                        "spotType", "CAFE",
-                        "updatedAt", "2025-08-06T10:30:00"
-                ),
-                Map.of(
-                        "id", 4L,
-                        "userNickname", "김창균",
-                        "spotName", "스시효 청담",
-                        "spotStatus", "PENDING",
-                        "spotType", "RESTAURANT",
-                        "updatedAt", "2025-08-06T10:45:00"
-                ),
-                Map.of(
-                        "id", 5L,
-                        "userNickname", "박지현",
-                        "spotName", "홍연참치 논현",
-                        "spotStatus", "PENDING",
-                        "spotType", "RESTAURANT",
-                        "updatedAt", "2025-08-06T11:00:00"
-                ),
-                Map.of(
-                        "id", 6L,
-                        "userNickname", "이상일",
-                        "spotName", "리틀넥 성수 브런치",
-                        "spotStatus", "PENDING",
-                        "spotType", "RESTAURANT",
-                        "updatedAt", "2025-08-06T11:15:00"
-                ),
-                Map.of(
-                        "id", 7L,
-                        "userNickname", "이수민",
-                        "spotName", "로리스 더 프라임 립 강남",
-                        "spotStatus", "PENDING",
-                        "spotType", "RESTAURANT",
-                        "updatedAt", "2025-08-06T11:30:00"
-                )
+        return ResponseEntity.ok(
+                adminService.getSpots(query, queryTarget, spotStatusList, missingField)
         );
-
-        return ResponseEntity.ok(Map.of("spotList", spotList));
     }
 
     @GetMapping(path = "/spots/{spotId}", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/acon/server/admin/api/response/SpotListResponse.java
+++ b/src/main/java/com/acon/server/admin/api/response/SpotListResponse.java
@@ -1,0 +1,36 @@
+package com.acon.server.admin.api.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record SpotListResponse(
+        List<SpotItem> spotList
+) {
+
+    public static SpotListResponse of(List<SpotItem> spotList) {
+        return new SpotListResponse(spotList);
+    }
+
+    public record SpotItem(
+            Long id,
+            String userNickname,
+            String spotName,
+            String spotStatus,
+            String spotType,
+            @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime updatedAt
+    ) {
+
+        public static SpotItem of(
+                Long id,
+                String userNickname,
+                String spotName,
+                String spotStatus,
+                String spotType,
+                LocalDateTime updatedAt
+        ) {
+            return new SpotItem(id, userNickname, spotName, spotStatus, spotType, updatedAt);
+        }
+    }
+}

--- a/src/main/java/com/acon/server/admin/application/service/AdminService.java
+++ b/src/main/java/com/acon/server/admin/application/service/AdminService.java
@@ -1,8 +1,19 @@
 package com.acon.server.admin.application.service;
 
 import com.acon.server.admin.api.response.DashboardResponse;
+import com.acon.server.admin.api.response.SpotListResponse;
+import com.acon.server.admin.api.response.SpotListResponse.SpotItem;
+import com.acon.server.admin.domain.enums.MissingField;
+import com.acon.server.admin.domain.enums.QueryTarget;
+import com.acon.server.admin.infra.entity.AdminEntity;
+import com.acon.server.admin.infra.repository.AdminRepository;
+import com.acon.server.admin.infra.repository.AdminSpotRepository;
+import com.acon.server.member.infra.entity.MemberEntity;
+import com.acon.server.member.infra.repository.MemberRepository;
 import com.acon.server.spot.domain.enums.SpotStatus;
+import com.acon.server.spot.infra.entity.SpotEntity;
 import com.acon.server.spot.infra.repository.SpotRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,11 +23,58 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminService {
 
     private final SpotRepository spotRepository;
+    private final MemberRepository memberRepository;
+    private final AdminRepository adminRepository;
+    private final AdminSpotRepository adminSpotRepository;
 
     @Transactional(readOnly = true)
     public DashboardResponse getDashboard() {
         int pendingSpotCount = (int) spotRepository.countBySpotStatus(SpotStatus.PENDING);
 
         return DashboardResponse.of(pendingSpotCount);
+    }
+
+    @Transactional(readOnly = true)
+    public SpotListResponse getSpots(
+            String query,
+            QueryTarget queryTarget,
+            List<SpotStatus> spotStatusList,
+            MissingField missingField
+    ) {
+        List<SpotEntity> spotEntityList = adminSpotRepository.findSpotsByFilters(
+                query,
+                queryTarget,
+                spotStatusList,
+                missingField
+        );
+
+        List<SpotItem> spotItemList = spotEntityList.stream()
+                .map(spotEntity -> {
+                    String userNickname;
+
+                    if (spotEntity.getAppliedUserId() == null) {
+                        userNickname = "ADMIN";
+                    } else if (Boolean.TRUE.equals(spotEntity.getAppliedByMember())) {
+                        MemberEntity memberEntity = memberRepository.findById(spotEntity.getAppliedUserId())
+                                .orElse(null);
+                        userNickname = memberEntity != null ? memberEntity.getNickname() : "탈퇴한 유저";
+                    } else {
+                        AdminEntity adminEntity = adminRepository.findById(spotEntity.getAppliedUserId())
+                                .orElse(null);
+                        userNickname = adminEntity != null ? adminEntity.getUsername() + "(ADMIN)" : "탈퇴한 어드민";
+                    }
+
+                    return SpotItem.of(
+                            spotEntity.getId(),
+                            userNickname,
+                            spotEntity.getName(),
+                            spotEntity.getSpotStatus().name(),
+                            spotEntity.getSpotType().name(),
+                            spotEntity.getUpdatedAt()
+                    );
+                })
+                .toList();
+
+        return SpotListResponse.of(spotItemList);
     }
 }

--- a/src/main/java/com/acon/server/admin/domain/enums/MissingField.java
+++ b/src/main/java/com/acon/server/admin/domain/enums/MissingField.java
@@ -1,0 +1,34 @@
+package com.acon.server.admin.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum MissingField {
+
+    ALL,
+    SPOT_IMAGE,
+    OPENING_HOURS,
+    ;
+
+    private static final Map<String, MissingField> MISSING_FIELD_MAP = new HashMap<>();
+
+    static {
+        for (MissingField missingField : MissingField.values()) {
+            MISSING_FIELD_MAP.put(missingField.name(), missingField);
+        }
+    }
+
+    @JsonCreator
+    public static MissingField fromValue(String value) {
+        MissingField missingField = MISSING_FIELD_MAP.get(value.toUpperCase());
+
+        if (missingField == null) {
+            throw new BusinessException(ErrorType.INVALID_MISSING_FIELD_ERROR);
+        }
+
+        return missingField;
+    }
+}

--- a/src/main/java/com/acon/server/admin/domain/enums/QueryTarget.java
+++ b/src/main/java/com/acon/server/admin/domain/enums/QueryTarget.java
@@ -1,0 +1,32 @@
+package com.acon.server.admin.domain.enums;
+
+import com.acon.server.global.exception.BusinessException;
+import com.acon.server.global.exception.ErrorType;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum QueryTarget {
+
+    SPOT_ID,
+    USER_NICKNAME,
+    SPOT_NAME,
+    ;
+
+    private static final Map<String, QueryTarget> QUERY_TARGET_MAP = new HashMap<>();
+
+    static {
+        for (QueryTarget queryTarget : QueryTarget.values()) {
+            QUERY_TARGET_MAP.put(queryTarget.name(), queryTarget);
+        }
+    }
+
+    public static QueryTarget fromValue(String value) {
+        QueryTarget queryTarget = QUERY_TARGET_MAP.get(value.toUpperCase());
+
+        if (queryTarget == null) {
+            throw new BusinessException(ErrorType.INVALID_QUERY_TARGET_ERROR);
+        }
+
+        return queryTarget;
+    }
+}

--- a/src/main/java/com/acon/server/admin/infra/repository/AdminSpotRepository.java
+++ b/src/main/java/com/acon/server/admin/infra/repository/AdminSpotRepository.java
@@ -1,0 +1,150 @@
+package com.acon.server.admin.infra.repository;
+
+import com.acon.server.admin.domain.enums.MissingField;
+import com.acon.server.admin.domain.enums.QueryTarget;
+import com.acon.server.member.infra.entity.QMemberEntity;
+import com.acon.server.spot.domain.enums.SpotStatus;
+import com.acon.server.spot.infra.entity.QMenuEntity;
+import com.acon.server.spot.infra.entity.QMenuboardImageEntity;
+import com.acon.server.spot.infra.entity.QOpeningHourEntity;
+import com.acon.server.spot.infra.entity.QSpotEntity;
+import com.acon.server.spot.infra.entity.QSpotImageEntity;
+import com.acon.server.spot.infra.entity.SpotEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminSpotRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<SpotEntity> findSpotsByFilters(
+            String query,
+            QueryTarget queryTarget,
+            List<SpotStatus> spotStatusList,
+            MissingField missingField
+    ) {
+        QSpotEntity spot = QSpotEntity.spotEntity;
+        QMemberEntity member = QMemberEntity.memberEntity;
+        QSpotImageEntity spotImage = QSpotImageEntity.spotImageEntity;
+        QOpeningHourEntity openingHour = QOpeningHourEntity.openingHourEntity;
+        QMenuboardImageEntity menuboardImage = QMenuboardImageEntity.menuboardImageEntity;
+        QMenuEntity menu = QMenuEntity.menuEntity;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 상태 필터
+        if (spotStatusList != null && !spotStatusList.isEmpty()) {
+            builder.and(spot.spotStatus.in(spotStatusList));
+        }
+
+        // 검색어 필터
+        if (query != null && !query.isBlank() && queryTarget != null) {
+            switch (queryTarget) {
+                case SPOT_ID -> {
+                    try {
+                        Long spotId = Long.parseLong(query);
+                        builder.and(spot.id.eq(spotId));
+                    } catch (NumberFormatException e) {
+                        // ID 파싱 실패 시 검색 결과 없음
+                        builder.and(spot.id.eq(-1L)); // 불가능한 ID로 결과 없게 함
+                    }
+                }
+                case SPOT_NAME -> builder.and(spot.name.containsIgnoreCase(query));
+                case USER_NICKNAME -> {
+                    // appliedUserId를 통해 Member 또는 Admin 조인하여 nickname 검색
+                    // 1. Member에서 검색
+                    List<Long> memberIds = queryFactory
+                            .select(member.id)
+                            .from(member)
+                            .where(member.nickname.containsIgnoreCase(query))
+                            .fetch();
+
+                    // 2. Admin에서 검색 (ADMIN 포함된 검색어 처리)
+                    // AdminEntity를 사용하여 검색하는 로직은 AdminService에서 처리
+                    // 여기서는 Member 검색만 수행
+
+                    if (!memberIds.isEmpty()) {
+                        builder.and(spot.appliedUserId.in(memberIds).and(spot.appliedByMember.eq(true)));
+                    } else if (query.toUpperCase().contains("ADMIN")) {
+                        // ADMIN 키워드가 있으면 appliedByMember가 false인 것만 검색
+                        builder.and(spot.appliedByMember.eq(false));
+                    } else {
+                        builder.and(spot.appliedUserId.eq(-1L)); // 결과 없게 함
+                    }
+                }
+            }
+        }
+
+        // 누락 필드 필터
+        if (missingField != null) {
+            switch (missingField) {
+                case SPOT_IMAGE -> {
+                    builder.and(
+                            JPAExpressions.selectOne()
+                                    .from(spotImage)
+                                    .where(spotImage.spotId.eq(spot.id))
+                                    .notExists()
+                    );
+                }
+                case OPENING_HOURS -> {
+                    builder.and(
+                            JPAExpressions.selectOne()
+                                    .from(openingHour)
+                                    .where(openingHour.spotId.eq(spot.id))
+                                    .notExists()
+                    );
+                }
+                case ALL -> {
+                    // 장소 이미지, 영업시간, 메뉴판 이미지, 메뉴 중 하나라도 없는 경우
+                    BooleanBuilder missingFieldBuilder = new BooleanBuilder();
+
+                    // 장소 이미지 없는 경우
+                    missingFieldBuilder.or(
+                            JPAExpressions.selectOne()
+                                    .from(spotImage)
+                                    .where(spotImage.spotId.eq(spot.id))
+                                    .notExists()
+                    );
+
+                    // 영업시간 없는 경우
+                    missingFieldBuilder.or(
+                            JPAExpressions.selectOne()
+                                    .from(openingHour)
+                                    .where(openingHour.spotId.eq(spot.id))
+                                    .notExists()
+                    );
+
+                    // 메뉴판 이미지 없는 경우
+                    missingFieldBuilder.or(
+                            JPAExpressions.selectOne()
+                                    .from(menuboardImage)
+                                    .where(menuboardImage.spotId.eq(spot.id))
+                                    .notExists()
+                    );
+
+                    // 메뉴 없는 경우
+                    missingFieldBuilder.or(
+                            JPAExpressions.selectOne()
+                                    .from(menu)
+                                    .where(menu.spotId.eq(spot.id))
+                                    .notExists()
+                    );
+
+                    builder.and(missingFieldBuilder);
+                }
+            }
+        }
+
+        return queryFactory
+                .selectFrom(spot)
+                .where(builder)
+                .orderBy(spot.updatedAt.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/acon/server/admin/infra/repository/AdminSpotRepository.java
+++ b/src/main/java/com/acon/server/admin/infra/repository/AdminSpotRepository.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
+// TODO: pagination 적용
 public class AdminSpotRepository {
 
     private final JPAQueryFactory queryFactory;

--- a/src/main/java/com/acon/server/admin/infra/repository/AdminSpotRepository.java
+++ b/src/main/java/com/acon/server/admin/infra/repository/AdminSpotRepository.java
@@ -53,7 +53,7 @@ public class AdminSpotRepository {
                         builder.and(spot.id.eq(spotId));
                     } catch (NumberFormatException e) {
                         // ID 파싱 실패 시 검색 결과 없음
-                        builder.and(spot.id.eq(-1L)); // 불가능한 ID로 결과 없게 함
+                        builder.and(spot.id.isNull().and(spot.id.isNotNull())); // 결과 없게 함 (항상 false)
                     }
                 }
                 case SPOT_NAME -> builder.and(spot.name.containsIgnoreCase(query));
@@ -76,7 +76,7 @@ public class AdminSpotRepository {
                         // ADMIN 키워드가 있으면 appliedByMember가 false인 것만 검색
                         builder.and(spot.appliedByMember.eq(false));
                     } else {
-                        builder.and(spot.appliedUserId.eq(-1L)); // 결과 없게 함
+                        builder.and(spot.id.isNull().and(spot.id.isNotNull())); // 결과 없게 함 (항상 false)
                     }
                 }
             }

--- a/src/main/java/com/acon/server/global/config/QueryDslConfig.java
+++ b/src/main/java/com/acon/server/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.acon.server.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/acon/server/global/exception/ErrorType.java
+++ b/src/main/java/com/acon/server/global/exception/ErrorType.java
@@ -40,6 +40,10 @@ public enum ErrorType {
     S3_FILE_OPERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50006, "S3 파일 작업 도중 에러가 발생했습니다."),
 
     /* Admin Error */
+    /* 400 Bad Request */
+    INVALID_QUERY_TARGET_ERROR(HttpStatus.BAD_REQUEST, 40057, "유효하지 않은 queryTarget입니다."),
+    INVALID_MISSING_FIELD_ERROR(HttpStatus.BAD_REQUEST, 40058, "유효하지 않은 missingField입니다."),
+
     /* 401 Unauthorized */
     INVALID_ID_OR_PASSWORD_ERROR(HttpStatus.UNAUTHORIZED, 40105, "아이디 또는 비밀번호가 일치하지 않습니다."),
 

--- a/src/main/java/com/acon/server/spot/api/controller/SpotControllerV1.java
+++ b/src/main/java/com/acon/server/spot/api/controller/SpotControllerV1.java
@@ -2,12 +2,12 @@ package com.acon.server.spot.api.controller;
 
 import com.acon.server.global.auth.PrincipalHandler;
 import com.acon.server.spot.api.request.ApplySpotRequest;
-import com.acon.server.spot.api.request.SpotListRequest;
+import com.acon.server.spot.api.request.RecommendedSpotListRequest;
 import com.acon.server.spot.api.response.MenuboardImageListResponse;
+import com.acon.server.spot.api.response.RecommendedSpotListResponse;
 import com.acon.server.spot.api.response.ReviewAvailabilityResponse;
 import com.acon.server.spot.api.response.SearchSuggestionListResponse;
 import com.acon.server.spot.api.response.SpotDetailResponse;
-import com.acon.server.spot.api.response.SpotListResponse;
 import com.acon.server.spot.api.response.SpotSearchListResponse;
 import com.acon.server.spot.application.service.SpotService;
 import jakarta.validation.Valid;
@@ -39,14 +39,14 @@ public class SpotControllerV1 {
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<SpotListResponse> getRecommendedSpotList(
-            @Valid @RequestBody final SpotListRequest request
+    public ResponseEntity<RecommendedSpotListResponse> getRecommendedSpotList(
+            @Valid @RequestBody final RecommendedSpotListRequest request
     ) {
         // TODO: 추후 서비스단에서 검증하도록 변경 요망
         if (!principalHandler.isGuestUser() && spotService.checkTestUser()) {
             return ResponseEntity.ok(
                     spotService.fetchRecommendedSpotList(
-                            new SpotListRequest(37.4940494, 127.030027, request.condition())
+                            new RecommendedSpotListRequest(37.4940494, 127.030027, request.condition())
                     )
             );
         }

--- a/src/main/java/com/acon/server/spot/api/request/RecommendedSpotListRequest.java
+++ b/src/main/java/com/acon/server/spot/api/request/RecommendedSpotListRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record SpotListRequest(
+public record RecommendedSpotListRequest(
         @NotNull(message = "위도는 필수입니다.")
         Double latitude,
 

--- a/src/main/java/com/acon/server/spot/api/response/RecommendedSpotListResponse.java
+++ b/src/main/java/com/acon/server/spot/api/response/RecommendedSpotListResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 import lombok.Builder;
 
 @JsonInclude(Include.NON_NULL)
-public record SpotListResponse(
+public record RecommendedSpotListResponse(
         String transportMode,
         List<RecommendedSpot> spotList
 ) {

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -16,15 +16,15 @@ import com.acon.server.member.infra.repository.SavedSpotRepository;
 import com.acon.server.review.infra.entity.ReviewEntity;
 import com.acon.server.review.infra.repository.ReviewRepository;
 import com.acon.server.spot.api.request.ApplySpotRequest;
-import com.acon.server.spot.api.request.SpotListRequest;
+import com.acon.server.spot.api.request.RecommendedSpotListRequest;
 import com.acon.server.spot.api.response.MenuResponse;
 import com.acon.server.spot.api.response.MenuboardImageListResponse;
+import com.acon.server.spot.api.response.RecommendedSpotListResponse;
+import com.acon.server.spot.api.response.RecommendedSpotListResponse.RecommendedSpot;
 import com.acon.server.spot.api.response.ReviewAvailabilityResponse;
 import com.acon.server.spot.api.response.SearchSuggestionListResponse;
 import com.acon.server.spot.api.response.SearchSuggestionResponse;
 import com.acon.server.spot.api.response.SpotDetailResponse;
-import com.acon.server.spot.api.response.SpotListResponse;
-import com.acon.server.spot.api.response.SpotListResponse.RecommendedSpot;
 import com.acon.server.spot.api.response.SpotSearchListResponse;
 import com.acon.server.spot.api.response.SpotSearchListResponse.SearchedSpot;
 import com.acon.server.spot.application.mapper.SpotMapper;
@@ -169,7 +169,7 @@ public class SpotService {
     // TODO: 변수명 정리
 
     @Transactional(readOnly = true)
-    public SpotListResponse fetchRecommendedSpotList(final SpotListRequest request) {
+    public RecommendedSpotListResponse fetchRecommendedSpotList(final RecommendedSpotListRequest request) {
         if (isOutOfServiceArea(request.latitude(), request.longitude())) {
             throw new BusinessException(ErrorType.UNAVAILABLE_SERVICE_AREA_ERROR);
         }
@@ -204,7 +204,7 @@ public class SpotService {
                     .limit(15)
                     .toList();
 
-            return new SpotListResponse(transportMode, spotList);
+            return new RecommendedSpotListResponse(transportMode, spotList);
         }
 
         MemberEntity memberEntity = memberRepository.findByIdOrElseThrow(principalHandler.getMemberIdFromPrincipal());
@@ -238,7 +238,7 @@ public class SpotService {
                     .limit(15)
                     .toList();
 
-            return new SpotListResponse(transportMode, spotList);
+            return new RecommendedSpotListResponse(transportMode, spotList);
         }
 
         // ========== [ CASE 2: preferenceEntity가 있는 사용자 ] ==========
@@ -258,7 +258,7 @@ public class SpotService {
                 .limit(15)
                 .toList();
 
-        return new SpotListResponse(transportMode, spotList);
+        return new RecommendedSpotListResponse(transportMode, spotList);
     }
 
     private boolean isOutOfServiceArea(
@@ -271,7 +271,7 @@ public class SpotService {
 
     // TODO: 카테고리 필터 enum 처리 급해요
     private List<SpotEntity> filterSpotList(
-            final SpotListRequest request,
+            final RecommendedSpotListRequest request,
             final double radius
     ) {
         return spotNativeQueryRepository.findSpotList(

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -616,7 +616,8 @@ public class SpotService {
                         .name(request.spotName())
                         .address(request.address())
                         .spotType(request.spotType())
-                        .appliedMemberId(memberId)
+                        .appliedUserId(memberId)
+                        .appliedByMember(true)
                         .spotStatus(SpotStatus.PENDING)
                         .build()
         );

--- a/src/main/java/com/acon/server/spot/domain/entity/Spot.java
+++ b/src/main/java/com/acon/server/spot/domain/entity/Spot.java
@@ -18,7 +18,8 @@ public class Spot {
     private final String name;
     private final SpotType spotType;
     private final String address;
-    private final Long appliedMemberId;
+    private final Long appliedUserId;
+    private final Boolean appliedByMember;
 
     private Integer localAcornCount;
     private Integer basicAcornCount;
@@ -36,7 +37,8 @@ public class Spot {
             String name,
             SpotType spotType,
             String address,
-            Long appliedMemberId,
+            Long appliedUserId,
+            Boolean appliedByMember,
             Integer localAcornCount,
             Integer basicAcornCount,
             Double latitude,
@@ -51,7 +53,8 @@ public class Spot {
         this.name = name;
         this.spotType = spotType;
         this.address = address;
-        this.appliedMemberId = appliedMemberId;
+        this.appliedUserId = appliedUserId;
+        this.appliedByMember = appliedByMember;
         this.localAcornCount = localAcornCount;
         this.basicAcornCount = basicAcornCount;
         this.latitude = latitude;

--- a/src/main/java/com/acon/server/spot/domain/enums/SpotStatus.java
+++ b/src/main/java/com/acon/server/spot/domain/enums/SpotStatus.java
@@ -22,8 +22,8 @@ public enum SpotStatus {
     private static final Map<String, SpotStatus> SPOT_STATUS_MAP = new HashMap<>();
 
     static {
-        for (SpotStatus status : SpotStatus.values()) {
-            SPOT_STATUS_MAP.put(status.name(), status);
+        for (SpotStatus spotStatus : SpotStatus.values()) {
+            SPOT_STATUS_MAP.put(spotStatus.name(), spotStatus);
         }
     }
 

--- a/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
+++ b/src/main/java/com/acon/server/spot/infra/entity/SpotEntity.java
@@ -87,8 +87,11 @@ public class SpotEntity {
     @Column(name = "legal_dong")
     private String legalDong;
 
-    @Column(name = "applied_member_id")
-    private Long appliedMemberId;
+    @Column(name = "applied_user_id")
+    private Long appliedUserId;
+
+    @Column(name = "applied_by_member", nullable = false)
+    private Boolean appliedByMember;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "spot_status", length = 20, nullable = false)
@@ -114,7 +117,8 @@ public class SpotEntity {
             Double longitude,
             Point geom,
             String legalDong,
-            Long appliedMemberId,
+            Long appliedUserId,
+            Boolean appliedByMember,
             SpotStatus spotStatus,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
@@ -130,7 +134,8 @@ public class SpotEntity {
         this.longitude = longitude;
         this.geom = geom;
         this.legalDong = legalDong;
-        this.appliedMemberId = appliedMemberId;
+        this.appliedUserId = appliedUserId;
+        this.appliedByMember = appliedByMember;
         this.spotStatus = spotStatus;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
@@ -1,6 +1,6 @@
 package com.acon.server.spot.infra.repository;
 
-import com.acon.server.spot.api.request.SpotListRequest.Condition.Filter;
+import com.acon.server.spot.api.request.RecommendedSpotListRequest.Condition.Filter;
 import com.acon.server.spot.domain.enums.SpotType;
 import com.acon.server.spot.infra.entity.SpotEntity;
 import jakarta.persistence.EntityManager;


### PR DESCRIPTION
# 💡 Issue
- resolved: #126 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 어드민 장소 목록 조회 API를 구현했습니다.
- 검색 API의 동적 쿼리를 효율적으로 처리하기 위해 QueryDSL을 도입했습니다.