### PR TITLE
[FIX/#136] 기존 API들에서 ACTIVE 상태인 장소만 조회 로직에 포함되도록 수정

### DIFF
--- a/src/main/java/com/acon/server/member/application/service/MemberService.java
+++ b/src/main/java/com/acon/server/member/application/service/MemberService.java
@@ -42,6 +42,7 @@ import com.acon.server.member.infra.repository.SavedSpotRepository;
 import com.acon.server.member.infra.repository.UpdatePolicyRepository;
 import com.acon.server.member.infra.repository.VerifiedAreaRepository;
 import com.acon.server.member.infra.repository.WithdrawalReasonRepository;
+import com.acon.server.spot.domain.enums.SpotStatus;
 import com.acon.server.spot.infra.entity.SpotEntity;
 import com.acon.server.spot.infra.entity.SpotImageEntity;
 import com.acon.server.spot.infra.repository.SpotImageRepository;
@@ -472,7 +473,7 @@ public class MemberService {
                         savedSpotEntity -> {
                             SpotEntity spotEntity = spotMap.get(savedSpotEntity.getSpotId());
 
-                            if (spotEntity == null) {
+                            if (spotEntity == null || spotEntity.getSpotStatus() != SpotStatus.ACTIVE) {
                                 return null;
                             }
 

--- a/src/main/java/com/acon/server/member/infra/repository/GuidedSpotCustomRepository.java
+++ b/src/main/java/com/acon/server/member/infra/repository/GuidedSpotCustomRepository.java
@@ -26,6 +26,7 @@ public class GuidedSpotCustomRepository {
                     FROM guided_spot gs
                     JOIN spot s ON s.id = gs.spot_id
                     WHERE gs.member_id = :memberId
+                      AND s.spot_status = 'ACTIVE'
                       AND ST_DWithin(
                           s.geom::geography,
                           ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -572,11 +572,11 @@ public class SpotService {
             return new SpotSearchListResponse(Collections.emptyList());
         }
 
-        List<SpotEntity> spotEntityList = spotRepository.findTop10ByNameStartingWithIgnoreCase(keyword);
+        List<SpotEntity> spotEntityList = spotRepository.findTop10ByNameStartingWithIgnoreCaseAndSpotStatus(keyword, SpotStatus.ACTIVE);
 
         if (spotEntityList.size() < SEARCH_LIMIT) {
             List<SpotEntity> additionalSpots = spotRepository.findByNameContainingWithLimitIgnoreCase(
-                    keyword, SEARCH_LIMIT - spotEntityList.size()
+                    keyword, SEARCH_LIMIT - spotEntityList.size(), SpotStatus.ACTIVE.name()
             );
 
             Set<Long> existingSpotIds = spotEntityList.stream()

--- a/src/main/java/com/acon/server/spot/application/service/SpotService.java
+++ b/src/main/java/com/acon/server/spot/application/service/SpotService.java
@@ -436,6 +436,10 @@ public class SpotService {
     ) {
         SpotEntity spotEntity = spotRepository.findByIdOrElseThrow(spotId);
 
+        if (spotEntity.getSpotStatus() != SpotStatus.ACTIVE) {
+            throw new BusinessException(ErrorType.NOT_FOUND_SPOT_ERROR);
+        }
+
         List<SpotImageEntity> spotImageEntityList = spotImageRepository.findAllBySpotIdOrderById(spotId);
         List<String> imageList = spotImageEntityList.stream()
                 .map(SpotImageEntity::getImage)

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotNativeQueryRepository.java
@@ -1,6 +1,7 @@
 package com.acon.server.spot.infra.repository;
 
 import com.acon.server.spot.api.request.RecommendedSpotListRequest.Condition.Filter;
+import com.acon.server.spot.domain.enums.SpotStatus;
 import com.acon.server.spot.domain.enums.SpotType;
 import com.acon.server.spot.infra.entity.SpotEntity;
 import jakarta.persistence.EntityManager;
@@ -33,7 +34,8 @@ public class SpotNativeQueryRepository {
                 .append("        ST_SetSRID(ST_MakePoint(:lng, :lat),4326)::geography,\n")
                 .append("        :radius\n")
                 .append(")\n")
-                .append("  AND s.spot_type = :spotType\n");
+                .append("  AND s.spot_type = :spotType\n")
+                .append("  AND s.spot_status = :spotStatus\n");
 
         if (filterList != null && !filterList.isEmpty()) {
             for (int i = 0; i < filterList.size(); i++) {
@@ -63,6 +65,7 @@ public class SpotNativeQueryRepository {
         query.setParameter("lng", longitude);
         query.setParameter("radius", radius);
         query.setParameter("spotType", spotType.name());
+        query.setParameter("spotStatus", SpotStatus.ACTIVE.name());
 
         if (filterList != null && !filterList.isEmpty()) {
             for (int i = 0; i < filterList.size(); i++) {

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotRepository.java
@@ -54,7 +54,8 @@ public interface SpotRepository extends JpaRepository<SpotEntity, Long> {
     @Query(value = """
             SELECT s.id, s.name
             FROM spot s
-            WHERE ST_DWithin(
+            WHERE s.spot_status = 'ACTIVE'
+              AND ST_DWithin(
                 s.geom,
                 ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326),
                 :radius

--- a/src/main/java/com/acon/server/spot/infra/repository/SpotRepository.java
+++ b/src/main/java/com/acon/server/spot/infra/repository/SpotRepository.java
@@ -20,7 +20,7 @@ public interface SpotRepository extends JpaRepository<SpotEntity, Long> {
 
     boolean existsByNameAndAddressAndSpotStatusAndIdNot(String name, String address, SpotStatus spotStatus, Long id);
 
-    List<SpotEntity> findTop10ByNameStartingWithIgnoreCase(String keyword);
+    List<SpotEntity> findTop10ByNameStartingWithIgnoreCaseAndSpotStatus(String keyword, SpotStatus spotStatus);
 
     List<SpotEntity> findAllByLatitudeIsNullOrLongitudeIsNullOrGeomIsNullOrLegalDongIsNull();
 
@@ -44,11 +44,13 @@ public interface SpotRepository extends JpaRepository<SpotEntity, Long> {
             SELECT *
             FROM spot
             WHERE name ILIKE %:keyword%
+              AND spot_status = :spotStatus
             LIMIT :limit
             """, nativeQuery = true)
     List<SpotEntity> findByNameContainingWithLimitIgnoreCase(
             @Param("keyword") String keyword,
-            @Param("limit") int limit
+            @Param("limit") int limit,
+            @Param("spotStatus") String spotStatus
     );
 
     @Query(value = """


### PR DESCRIPTION
# 💡 Issue
- resolved: #136 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 기존 API들에서 ACTIVE 상태인 장소만 조회 로직에 포함되도록 수정했습니다.